### PR TITLE
Fix rates rebates income threshold beginning dates

### DIFF
--- a/openfisca_aotearoa/tests/rates_rebates.yaml
+++ b/openfisca_aotearoa/tests/rates_rebates.yaml
@@ -1,8 +1,7 @@
-# Test files describe situations and their expected outcomes
 # We can run this test on our command line using `openfisca-run-test openfisca_aotearoa/tests/rates_rebates.yaml`
 
-# these tests need testing, outputs not yet validated
-- name: Someone earning 32103 with no dependants and rates of 2000 should get a rebate of 313 in 2017
+# These tests have been created with the Universal Rates Rebate Calculator spreadsheet provided by the DIA Rates Rebate team
+- name: Someone earning 32103 with no dependants and rates of 2000
   period: 2017
   absolute_error_margin: 1
   input_variables:
@@ -10,8 +9,8 @@
     dependants: 0
     rates: 2000
   output_variables:
-    rates_rebate: 313
-- name: Someone earning 35000 with two dependants and rates of 2200 should get a rebate of 84 in 2017
+    rates_rebate: 312.67
+- name: Someone earning 35000 with two dependants and rates of 2200
   period: 2017
   absolute_error_margin: 1
   input_variables:
@@ -19,8 +18,8 @@
     dependants: 2
     rates: 2200
   output_variables:
-    rates_rebate: 208
-- name: Someone earning 70000 with two dependants and rates of 2200 should get a rebate of 0 in 2017
+    rates_rebate: 209
+- name: Someone earning 70000 with two dependants and rates of 2200
   period: 2017
   absolute_error_margin: 1
   input_variables:

--- a/openfisca_aotearoa/variables/ratesrebates.py
+++ b/openfisca_aotearoa/variables/ratesrebates.py
@@ -1,9 +1,5 @@
 # -*- coding: utf-8 -*-
 
-# This file defines the variables of our legislation.
-# A variable is property of a person, or an entity (e.g. a property).
-# See http://openfisca.org/doc/variables.html
-
 # Import from openfisca-core the common python objects used to code the legislation in OpenFisca
 from openfisca_core.model_api import *
 # Import the entities specifically defined for this tax and benefit system
@@ -61,7 +57,7 @@ class maximum_income_for_full_rebate(Variable):
     entity = Propertee
     definition_period = YEAR
     label = "Maximum income eligible for the full rebate, less than this number should get full rebate"
-    reference = "https://stats.gov.example/disposable_income"  # Some variables represent quantities used in economic models, and not defined by law. Always give the source of your definition.
+    reference = ""
 
     def formula(properties, period, parameters):
         ratesperiod = period.offset(-6, 'month')
@@ -82,7 +78,7 @@ class minimum_income_for_no_rebate(Variable):
     entity = Propertee
     definition_period = YEAR
     label = "Minimum income that returns no rebate. Less than this number gets a rebate"
-    reference = "https://stats.gov.example/disposable_income"  # Some variables represent quantities used in economic models, and not defined by law. Always give the source of your definition.
+    reference = ""
 
     def formula(properties, period, parameters):
         ratesperiod = period.offset(-6, 'month')


### PR DESCRIPTION
* Tax and benefit system evolution.
* Impacted periods: from 1973-06-01.
* Impacted areas: `parameters/benefits/rates_rebates/income_threshold`
* Details:
  - July was misrepresented as June

- - - -

These changes:

- Fix or improve an already existing calculation.
