### PR TITLE
Remove date offset as not best practice

### DIFF
--- a/openfisca_aotearoa/variables/ratesrebates.py
+++ b/openfisca_aotearoa/variables/ratesrebates.py
@@ -41,7 +41,7 @@ class rates_rebate(Variable):
 
         # sum allowable income including all the dependants for property
         allowable_income = (properties.sum(properties.members('dependants', period)) * additional_per_dependant) + income_threshold
-        
+
         # calculate the excess income based on the allowable income
         excess_income = (properties.sum(properties.members('salary', period)) - allowable_income) / 8
 

--- a/openfisca_aotearoa/variables/ratesrebates.py
+++ b/openfisca_aotearoa/variables/ratesrebates.py
@@ -30,8 +30,8 @@ class rates_rebate(Variable):
     value_type = float
     entity = Propertee
     definition_period = YEAR
-    reference = "https://stats.gov.example/disposable_income"  # Some variables represent quantities used in economic models, and not defined by law. Always give the source of your definition.
     label = "Yearly rebate applied to housing rates. Defined on a calendar year, not a fiscal year."
+    reference = ""
 
     def formula(properties, period, parameters):
         income_threshold = parameters(period).benefits.rates_rebates.income_threshold

--- a/openfisca_aotearoa/variables/ratesrebates.py
+++ b/openfisca_aotearoa/variables/ratesrebates.py
@@ -34,14 +34,13 @@ class rates_rebate(Variable):
     reference = "https://stats.gov.example/disposable_income"  # Some variables represent quantities used in economic models, and not defined by law. Always give the source of your definition.
 
     def formula(properties, period, parameters):
-        ratesperiod = period.offset(-6, 'month')
-        income_threshold = parameters(ratesperiod).benefits.rates_rebates.income_threshold
-        additional_per_dependant = parameters(ratesperiod).benefits.rates_rebates.additional_per_dependant
-        initial_contribution = parameters(ratesperiod).benefits.rates_rebates.initial_contribution
-        maximum_allowable = parameters(ratesperiod).benefits.rates_rebates.maximum_allowable
+        income_threshold = parameters(period).benefits.rates_rebates.income_threshold
+        additional_per_dependant = parameters(period).benefits.rates_rebates.additional_per_dependant
+        initial_contribution = parameters(period).benefits.rates_rebates.initial_contribution
+        maximum_allowable = parameters(period).benefits.rates_rebates.maximum_allowable
 
         # sum allowable income including all the dependants for property
-        allowable_income = (properties.sum(properties.members('dependants', ratesperiod)) * additional_per_dependant) + income_threshold
+        allowable_income = (properties.sum(properties.members('dependants', period)) * additional_per_dependant) + income_threshold
         
         # calculate the excess income based on the allowable income
         excess_income = (properties.sum(properties.members('salary', period)) - allowable_income) / 8

--- a/openfisca_aotearoa/variables/ratesrebates.py
+++ b/openfisca_aotearoa/variables/ratesrebates.py
@@ -46,10 +46,10 @@ class rates_rebate(Variable):
         excess_income = (properties.sum(properties.members('salary', period)) - allowable_income) / 8
 
         # minus the initial contribution
-        ratesminuscontribution = properties('rates', period) - initial_contribution
+        rates_minus_contribution = properties('rates', period) - initial_contribution
 
         # perform the calculation
-        rebate = ratesminuscontribution - ((ratesminuscontribution / 3) + excess_income)
+        rebate = rates_minus_contribution - ((rates_minus_contribution / 3) + excess_income)
 
         # clips the results between 0 and the maximum_allowable
         return clip(rebate, 0, maximum_allowable)

--- a/openfisca_aotearoa/variables/ratesrebates.py
+++ b/openfisca_aotearoa/variables/ratesrebates.py
@@ -30,8 +30,8 @@ class rates_rebate(Variable):
     value_type = float
     entity = Propertee
     definition_period = YEAR
-    label = "Actual amount available to the person at the end of the month"
     reference = "https://stats.gov.example/disposable_income"  # Some variables represent quantities used in economic models, and not defined by law. Always give the source of your definition.
+    label = "Yearly rebate applied to housing rates. Defined on a calendar year, not a fiscal year."
 
     def formula(properties, period, parameters):
         income_threshold = parameters(period).benefits.rates_rebates.income_threshold


### PR DESCRIPTION
* Minor change.
* Impacted periods: all.
* Impacted areas: `openfisca_aotearoa/variables/ratesrebates.py`
* Details:
  - Remove dateoffset for accessing rates rebates parameters as is now meaningless with intended shorter term approach

- - - -
- Fix or improve an already existing calculation.