### PR TITLE
Expose host name in OpenAPI specification

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: openfisca serve --country-package openfisca_aotearoa --port $PORT --bind 0.0.0.0:$PORT
+web: SERVER_NAME=openfisca-aotearoa.herokuapp.com openfisca serve --country-package openfisca_aotearoa --port $PORT --bind 0.0.0.0:$PORT


### PR DESCRIPTION
* Technical improvement.
* Impacted periods: none.
* Impacted areas: Heroku deployment
* Details:
  - This changeset (hopefully) ensures that the `host` name in the OpenAPI specification is not `null`. See https://github.com/openfisca/openfisca-core/issues/665 for details.

- - - -

These changes:

- Change non-functional parts of this repository