### PR TITLE
Platform as a service

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,15 @@
 
 ## Writing the Legislation
 
-Aotearoa New Zealand's legislation as code utilising Open Fisca. 
-Early development phase. 
+Aotearoa New Zealand's legislation as code utilising Open Fisca.
+Early development phase.
 Please also read [the wiki](https://github.com/ServiceInnovationLab/openfisca-aotearoa/wiki) as a way of introduction.
 
 The files that are outside from the `openfisca_aotearoa` folder are used to set up the development environment.
+
+## Deploy to your own platform-as-a-service
+
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
 
 ## Install Instructions for Users and Contributors
 
@@ -54,7 +58,7 @@ Additional information:
 
 :tada: You are now ready to install this OpenFisca Country Package!
 
-We offer 2 install procedures. Pick procedure A or B below depending on how you plan to use this Country Package. 
+We offer 2 install procedures. Pick procedure A or B below depending on how you plan to use this Country Package.
 
 ### A. Minimal Installation (Pip Install)
 

--- a/app.json
+++ b/app.json
@@ -1,0 +1,17 @@
+{
+  "name": "openfisca-aotearoa",
+  "description": "",
+  "scripts": {},
+  "env": {},
+  "formation": {
+    "web": {
+      "quantity": 1
+    }
+  },
+  "addons": [],
+  "buildpacks": [
+    {
+      "url": "heroku/python"
+    }
+  ]
+}


### PR DESCRIPTION
`app.json` tells Heroku everything it needs to deploy an instance of the app. Then we can deploy the entire app with rules on each pull request, and have people test against this running on the internet

`README.md` add a button to allow quick deploys to Heroku - Other members of the D7 (or 9) were keen on having a quick way to deploy their own instance to play with. 

I want to add other PaaS to this very soon, so we don't end up Heroku-centric. 