### PR TITLE
moved linter to seperate circleci step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,3 +1,4 @@
+---
 # CircleCI 2.0 configuration file. See <https://circleci.com/docs/2.0/language-python/>.
 version: 2
 jobs:
@@ -37,6 +38,18 @@ jobs:
           name: Run tests
           command: make test
 
+  lint:
+    docker:
+      - image: circleci/python:2.7-stretch
+    steps:
+      - checkout
+      - run:
+          name: Install flake8
+          command: sudo pip install --upgrade flake8
+      - run:
+          name: Python linter
+          command: flake8
+
   version-bump:
     docker:
       - image: circleci/python:2.7-stretch
@@ -64,6 +77,7 @@ workflows:
   version: 2
   build_and_test:
     jobs:
+      - lint
       - build
       - version-bump
       # Uncomment the lines below when you have a Pypi account and you are ready to deploy your country package to reusers.

--- a/Makefile
+++ b/Makefile
@@ -3,5 +3,4 @@ clean:
 	find . -name '*.pyc' -exec rm \{\} \;
 
 test:
-	flake8
 	openfisca-run-test --country-package openfisca_aotearoa openfisca_aotearoa/tests


### PR DESCRIPTION
Technical improvement.

Move the linter to a separate circle-ci step, allowing pull request status to show which step is failing.

- - - -

These changes change non-functional parts of this repository
