### PR TITLE
Feature/others

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# 4.1.0 - [#41](https://github.com/ServiceInnovationLab/openfisca-aotearoa/pull/51)
+Calculation improvement.
+* Added "Others" role within a titled_property
+* Added "Others" role within a family
+
 # 4.0.2 - [#42](https://github.com/ServiceInnovationLab/openfisca-aotearoa/pull/22)
 Legislation improvement.
 * Added Accommodation Supplement from the Social Security Act 1964

--- a/openfisca_aotearoa/entities.py
+++ b/openfisca_aotearoa/entities.py
@@ -23,6 +23,12 @@ Titled_Property = build_entity(
             'plural': 'owners',
             'label': u'Owners',
             'doc': u'The one or more persons who hold title for the property.'
+            },
+        {
+            'key': 'other',
+            'plural': 'others',
+            'label': u'Others',
+            'doc': u'People who are not in any other role'
             }
         ]
     )
@@ -79,6 +85,12 @@ Family = build_entity(
             'plural': 'children',
             'label': u'Children',
             'doc': u'The children of a family.'
+            },
+        {
+            'key': 'other',
+            'plural': 'others',
+            'label': u'Other',
+            'doc': u'All other members of a family/whānau.'
             }
         ]
     )


### PR DESCRIPTION
* Details:

People may belong to a family (or a titled_property) but not in any of the existing defined roles. 
Open Fisca core currently requires all people belong to one of these.
We can't say they're an owner when they're not, as this could cause the system to declare the person eligible for things they are not. So instead we have 2 new roles, both called "others", which give the person no actual benefits, but satisfies Open Fisca's calculation requirements.


- - - -
- Fix or improve an already existing calculation - allows requesting entitlements when you don't own any properties and are not a parent of a child. (fixes #48 )