### PR TITLE
turned off default date of birth

### DIFF
--- a/openfisca_aotearoa/variables/demographics/demographics.py
+++ b/openfisca_aotearoa/variables/demographics/demographics.py
@@ -9,7 +9,6 @@ from openfisca_aotearoa.entities import Person, Family
 # This variable is a pure input: it doesn't have a formula
 class date_of_birth(Variable):
     value_type = date
-    default_value = date(1970, 1, 1)  # By default, if no value is set for a simulation, we consider the people involved in a simulation to be born on the 1st of Jan 1970.
     entity = Person
     label = u"Birth date"
     definition_period = ETERNITY  # This variable cannot change over time.
@@ -19,7 +18,6 @@ class date_of_birth(Variable):
 # This variable is a pure input: it doesn't have a formula
 class due_date_of_birth(Variable):
     value_type = date
-    default_value = date(1970, 1, 1)  # By default, if no value is set for a simulation, we consider the people involved in a simulation to be born on the 1st of Jan 1970.
     entity = Person
     label = u"Birth due date"
     definition_period = ETERNITY  # This variable cannot change over time.


### PR DESCRIPTION
Removed the default date of birth. This was causing people to be considered eligible for things they should not be, e.g. newborn babies being eligible for benefits that are actually only for adults. We need to actually specify an age or DOB now to cause these benefits to be returned by OF