### PR TITLE
Added income test to WFF family tax credit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 5.1.0 - [#92](https://github.com/ServiceInnovationLab/openfisca-aotearoa/pull/92)
+* Tax and benefit system evolution. 
+  - adding income test to Family Tax Credit
+
 # 5.0.2 - [#88](https://github.com/ServiceInnovationLab/openfisca-aotearoa/pull/88)
 * Tax and benefit system evolution. 
   - added formula for is_permanent_resident

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Changelog
 
 # 5.1.0 - [#92](https://github.com/ServiceInnovationLab/openfisca-aotearoa/pull/92)
-* Tax and benefit system evolution. 
+* Tax and benefit system evolution.
   - adding income test to Family Tax Credit
+  - added variables `family_scheme__in_work_tax_credit_is_full_time_earner, family_scheme__in_work_tax_credit_income_under_threshold, family_scheme__family_tax_credit_income_under_threshold`
 
 # 5.0.2 - [#88](https://github.com/ServiceInnovationLab/openfisca-aotearoa/pull/88)
-* Tax and benefit system evolution. 
+* Tax and benefit system evolution.
   - added formula for is_permanent_resident
 
 # 5.0.1 - [#81](https://github.com/ServiceInnovationLab/openfisca-aotearoa/pull/81)

--- a/openfisca_aotearoa/tests/income_tax/family_scheme/family_tax_credit.yaml
+++ b/openfisca_aotearoa/tests/income_tax/family_scheme/family_tax_credit.yaml
@@ -27,3 +27,46 @@
       others: ["Papatūānuku", "Rakinui", "Tāne", "Rongo", "Ikatere"]
   output_variables:
     family_scheme__qualifies_for_family_tax_credit: [1, 0, 0, 0, 0]
+
+- name: Family tax credit - too much income
+  period: 2018-08
+  absolute_error_margin: 0
+  persons:
+    - id: "Papatūānuku"
+      date_of_birth: 1999-01-01
+      family_scheme__assessable_income:
+        2018: 42700
+  families:
+    - id: "Whanau"
+      principal_caregiver: "Papatūānuku"
+  titled_properties:
+    - id: "Whare"
+      others: ["Papatūānuku"]
+  output_variables:
+    family_scheme__qualifies_for_family_tax_credit:
+      2018-08:
+        - false
+
+- name: Family tax credit - too much income
+  period: 2018-08
+  absolute_error_margin: 0
+  persons:
+    - id: "Papatūānuku"
+      date_of_birth: 1999-01-01
+      family_scheme__assessable_income:
+        2018: 14233
+    - id: "Rakinui"
+      date_of_birth: 1996-01-01
+      family_scheme__assessable_income:
+        2018: 28470
+  families:
+    - id: "Whanau"
+      principal_caregiver: "Papatūānuku"
+      partners: ["Rakinui"]
+  titled_properties:
+    - id: "Whare"
+      others: ["Papatūānuku", "Rakinui"]
+  output_variables:
+    family_scheme__qualifies_for_family_tax_credit:
+      2018-08:
+        - false

--- a/openfisca_aotearoa/tests/income_tax/family_scheme/in_work_tax_credit.yaml
+++ b/openfisca_aotearoa/tests/income_tax/family_scheme/in_work_tax_credit.yaml
@@ -1,5 +1,5 @@
-# We can run this test on our command line using `openfisca-run-test openfisca_aotearoa/tests/income_tax/family_scheme/family_tax_credit.yaml`
-- name: Tests persons age eligibility in relation to the family tax credit
+# We can run this test on our command line using `openfisca-run-test openfisca_aotearoa/tests/income_tax/family_scheme/in_work_tax_credit.yaml`
+- name: Tests persons age eligibility in relation to the in work tax credit
   period: 2018-08
   absolute_error_margin: 0
   persons:
@@ -7,7 +7,8 @@
       date_of_birth: 1999-01-01
       family_scheme__assessable_income:
         2018: 20000
-      family_scheme__family_tax_credit_income_under_threshold: true
+      family_scheme__in_work_tax_credit_income_under_threshold: true
+      family_scheme__in_work_tax_credit_is_full_time_earner: true
     - id: "Rakinui"
       date_of_birth: 1996-01-01
       family_scheme__assessable_income:
@@ -27,8 +28,8 @@
     - id: "Whare"
       others: ["Papatūānuku", "Rakinui", "Tāne", "Rongo", "Ikatere"]
   output_variables:
-    family_scheme__qualifies_for_family_tax_credit: [1, 0, 0, 0, 0]
-- name: Tests persons income over threshold and not elible for family tax credit
+    family_scheme__qualifies_for_in_work_tax_credit: [1, 0, 0, 0, 0]
+- name: Tests persons income under threshold requirement in relation to the in work tax credit
   period: 2018-08
   absolute_error_margin: 0
   persons:
@@ -36,7 +37,8 @@
       date_of_birth: 1999-01-01
       family_scheme__assessable_income:
         2018: 20000
-      family_scheme__family_tax_credit_income_under_threshold: false
+      family_scheme__in_work_tax_credit_income_under_threshold: false
+      family_scheme__in_work_tax_credit_is_full_time_earner: true
     - id: "Rakinui"
       date_of_birth: 1996-01-01
       family_scheme__assessable_income:
@@ -56,38 +58,51 @@
     - id: "Whare"
       others: ["Papatūānuku", "Rakinui", "Tāne", "Rongo", "Ikatere"]
   output_variables:
-    family_scheme__qualifies_for_family_tax_credit: [0, 0, 0, 0, 0]
-- name: Family tax credit - too much income
+    family_scheme__qualifies_for_in_work_tax_credit: [0, 0, 0, 0, 0]
+- name: Tests persons full time earner requirement in relation to the in work tax credit
   period: 2018-08
   absolute_error_margin: 0
   persons:
     - id: "Papatūānuku"
       date_of_birth: 1999-01-01
       family_scheme__assessable_income:
-        2018: 42700
-  families:
-    - id: "Whanau"
-      principal_caregiver: "Papatūānuku"
-  titled_properties:
-    - id: "Whare"
-      others: ["Papatūānuku"]
-  output_variables:
-    family_scheme__qualifies_for_family_tax_credit:
-      2018-08:
-        - false
-
-- name: Family tax credit - too much income
-  period: 2018-08
-  absolute_error_margin: 0
-  persons:
-    - id: "Papatūānuku"
-      date_of_birth: 1999-01-01
-      family_scheme__assessable_income:
-        2018: 14233
+        2018: 20000
+      family_scheme__in_work_tax_credit_income_under_threshold: true
+      family_scheme__in_work_tax_credit_is_full_time_earner: false
     - id: "Rakinui"
       date_of_birth: 1996-01-01
       family_scheme__assessable_income:
-        2018: 28470
+        2018: 20000
+    - id: "Tāne"
+      date_of_birth: 2005-01-24
+    - id: "Rongo"
+      date_of_birth: 2007-03-08
+    - id: "Ikatere"
+      date_of_birth: 2012-03-08
+  families:
+    - id: "Whanau"
+      principal_caregiver: "Papatūānuku"
+      partners: ["Rakinui"]
+      children: ["Tāne", "Rongo", "Ikatere"]
+  titled_properties:
+    - id: "Whare"
+      others: ["Papatūānuku", "Rakinui", "Tāne", "Rongo", "Ikatere"]
+  output_variables:
+    family_scheme__qualifies_for_in_work_tax_credit: [0, 0, 0, 0, 0]
+- name: Tests persons age eligibility in relation to if they have children
+  period: 2018-08
+  absolute_error_margin: 0
+  persons:
+    - id: "Papatūānuku"
+      date_of_birth: 1999-01-01
+      family_scheme__assessable_income:
+        2018: 20000
+      family_scheme__in_work_tax_credit_income_under_threshold: true
+      family_scheme__in_work_tax_credit_is_full_time_earner: true
+    - id: "Rakinui"
+      date_of_birth: 1996-01-01
+      family_scheme__assessable_income:
+        2018: 20000
   families:
     - id: "Whanau"
       principal_caregiver: "Papatūānuku"
@@ -96,6 +111,4 @@
     - id: "Whare"
       others: ["Papatūānuku", "Rakinui"]
   output_variables:
-    family_scheme__qualifies_for_family_tax_credit:
-      2018-08:
-        - false
+    family_scheme__qualifies_for_in_work_tax_credit: [0, 0]

--- a/openfisca_aotearoa/variables/acts/income_tax/family_scheme/family_tax_credit.py
+++ b/openfisca_aotearoa/variables/acts/income_tax/family_scheme/family_tax_credit.py
@@ -12,7 +12,12 @@ class family_scheme__qualifies_for_family_tax_credit(Variable):
     reference = "http://www.legislation.govt.nz/act/public/2007/0097/latest/DLM1518484.html"
 
     def formula(persons, period, parameters):
-        return persons("family_scheme__base_qualifies", period)
+        family_income = persons.family.sum(persons.family.members(
+            "family_scheme__assessable_income", period.this_year))
+        threshold = parameters(
+            period).entitlements.income_tax.family_scheme.family_tax_credit.full_year_abatement_threshold
+        income_under_threshold = family_income < threshold
+        return persons("family_scheme__base_qualifies", period) * income_under_threshold
 
 
 class family_scheme__family_tax_credit_entitlement(Variable):
@@ -36,7 +41,8 @@ class family_scheme__family_tax_credit_entitlement(Variable):
         # income_over_threshold = where((family_income - threshold) < 0, 0, family_income - threshold)
 
         # calculate the number of children
-        number_of_children = persons.family.sum(persons("income_tax__dependent_child", period))
+        number_of_children = persons.family.sum(
+            persons("income_tax__dependent_child", period))
 
         # TODO this variable is incomplete and requires the formula to be finished
         return number_of_children

--- a/openfisca_aotearoa/variables/acts/income_tax/family_scheme/family_tax_credit.py
+++ b/openfisca_aotearoa/variables/acts/income_tax/family_scheme/family_tax_credit.py
@@ -12,12 +12,15 @@ class family_scheme__qualifies_for_family_tax_credit(Variable):
     reference = "http://www.legislation.govt.nz/act/public/2007/0097/latest/DLM1518484.html"
 
     def formula(persons, period, parameters):
-        family_income = persons.family.sum(persons.family.members(
-            "family_scheme__assessable_income", period.this_year))
-        threshold = parameters(
-            period).entitlements.income_tax.family_scheme.family_tax_credit.full_year_abatement_threshold
-        income_under_threshold = family_income < threshold
-        return persons("family_scheme__base_qualifies", period) * income_under_threshold
+        return persons("family_scheme__base_qualifies", period) * persons("family_scheme__family_tax_credit_income_under_threshold", period)
+
+
+class family_scheme__family_tax_credit_income_under_threshold(Variable):  # this variable is a proxy for the calculation "family_scheme__family_tax_credit_entitlement" which needs to be coded
+    value_type = bool
+    entity = Person
+    definition_period = MONTH
+    label = u'Is the person income under the threshold for the family tax credit'
+    reference = "http://www.legislation.govt.nz/act/public/2007/0097/latest/DLM1518484.html"
 
 
 class family_scheme__family_tax_credit_entitlement(Variable):

--- a/openfisca_aotearoa/variables/acts/income_tax/family_scheme/in_work_tax_credit.py
+++ b/openfisca_aotearoa/variables/acts/income_tax/family_scheme/in_work_tax_credit.py
@@ -17,7 +17,25 @@ class family_scheme__qualifies_for_in_work_tax_credit(Variable):
         received_parents_allowance = persons('veterans_support__received_parents_allowance', period)
         received_childrens_pension = persons('veterans_support__received_childrens_pension', period)
 
-        return base_qualifies * not_(received_tested_benefit) * not_(received_parents_allowance) * not_(received_childrens_pension)
+        return base_qualifies * not_(received_tested_benefit) * not_(received_parents_allowance) \
+            * not_(received_childrens_pension) * persons('family_scheme__in_work_tax_credit_income_under_threshold', period) \
+            * persons('family_scheme__in_work_tax_credit_is_full_time_earner', period)
+
+
+class family_scheme__in_work_tax_credit_income_under_threshold(Variable):  # this variable is a proxy for the calculation "family_scheme__in_work_tax_credit_entitlement" which needs to be coded
+    value_type = bool
+    entity = Person
+    definition_period = MONTH
+    label = u'Is the income under the threshold for the in work tax credit'
+    reference = "http://www.legislation.govt.nz/act/public/2007/0097/latest/DLM1518484.html"
+
+
+class family_scheme__in_work_tax_credit_is_full_time_earner(Variable):
+    value_type = bool
+    entity = Person
+    definition_period = MONTH
+    label = u'Is the income under the threshold for the in work tax credit'
+    reference = "http://www.legislation.govt.nz/act/public/2007/0097/latest/DLM1518419.html"
 
 
 class family_scheme__in_work_tax_credit_entitlement(Variable):

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='OpenFisca-Aotearoa',
-    version='5.0.2',
+    version='5.1.0',
     author='New Zealand Government, Service Innovation Lab',
     author_email='brenda.wallace@dia.govt.nz',
     description=u'OpenFisca tax and benefit system for Aotearoa',


### PR DESCRIPTION
* Tax and benefit system evolution.
* Impacted periods:  1 April 2017 to 31 March 2019
* Impacted areas: `parameters/entitlements/income_tax/family_scheme/family_tax_credit/full_year_abatement_threshold.yaml`

* Details:
Income  test was missing from Family Tax Credit formula

closes #91