### PR TITLE
Adding super___eligibility_age

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+# 5.1.3 - [#94](https://github.com/ServiceInnovationLab/openfisca-aotearoa/pull/97)
+* Refactored NZ Superannuation
+  - Added `super__eligible_age`
+  - Removed age requirement from `super__eligible`
+  - Removed `super__living_alone` and `super__has_partner_in_long_term_care_or_rest_home`
+
 # 5.1.2 - [#94](https://github.com/ServiceInnovationLab/openfisca-aotearoa/pull/94)
 * Added NZ Superannuation
 

--- a/openfisca_aotearoa/parameters/general/age_of_superannuation.yaml
+++ b/openfisca_aotearoa/parameters/general/age_of_superannuation.yaml
@@ -3,4 +3,4 @@ description: Age of superannuation (entitlement)
 reference: http://legislation.govt.nz/act/public/2001/0084/latest/DLM113987.html
 values:
   1898-01-01: # http://blog.tepapa.govt.nz/2017/03/09/a-brief-history-of-superannuation-in-new-zealand-1898-2020/
-    value: 65.0
+    value: 65

--- a/openfisca_aotearoa/tests/social_security/super.yaml
+++ b/openfisca_aotearoa/tests/social_security/super.yaml
@@ -4,57 +4,64 @@
   period: 2018-08
   absolute_error_margin: 0
   persons:
-    - id: "Is 65 or older"
-      is_citizen_or_resident: true
-      age: 68
+    - id: "Not eligible"
+      is_nz_citizen: false
       acc__is_receiving_compensation: false
       veterans_support__is_entitled_to_be_paid_veterans_pension: false
       total_number_of_years_lived_in_nz_since_age_20: 12
       total_number_of_years_lived_in_nz_since_age_50: 6
 
-    - id: "Is younger than 65"
-      is_citizen_or_resident: true
-      age: 33
+    - id: "Is Permanent Resident"
+      is_permanent_resident: true
+      acc__is_receiving_compensation: false
+      veterans_support__is_entitled_to_be_paid_veterans_pension: false
+      total_number_of_years_lived_in_nz_since_age_20: 11
+      total_number_of_years_lived_in_nz_since_age_50: 6
+
+    - id: "Is Resident"
+      is_resident: true
+      acc__is_receiving_compensation: false
+      veterans_support__is_entitled_to_be_paid_veterans_pension: false
+      total_number_of_years_lived_in_nz_since_age_20: 11
+      total_number_of_years_lived_in_nz_since_age_50: 6
+
+    - id: "Is citizen"
+      is_nz_citizen: true
       acc__is_receiving_compensation: false
       veterans_support__is_entitled_to_be_paid_veterans_pension: false
       total_number_of_years_lived_in_nz_since_age_20: 11
       total_number_of_years_lived_in_nz_since_age_50: 6
 
     - id: "Is receiving compensation"
-      is_citizen_or_resident: true
-      age: 65
+      is_nz_citizen: true
       acc__is_receiving_compensation: true
       veterans_support__is_entitled_to_be_paid_veterans_pension: false
       total_number_of_years_lived_in_nz_since_age_20: 11
       total_number_of_years_lived_in_nz_since_age_50: 6
 
     - id: "Is a Veteran"
-      is_citizen_or_resident: true
-      age: 65
+      is_nz_citizen: true
       acc__is_receiving_compensation: false
       veterans_support__is_entitled_to_be_paid_veterans_pension: true
       total_number_of_years_lived_in_nz_since_age_20: 11
       total_number_of_years_lived_in_nz_since_age_50: 6
 
     - id: "Is a NZ Citizen"
-      is_citizen_or_resident: true
-      age: 65
+      is_nz_citizen: true
       acc__is_receiving_compensation: false
       veterans_support__is_entitled_to_be_paid_veterans_pension: false
       total_number_of_years_lived_in_nz_since_age_20: 11
       total_number_of_years_lived_in_nz_since_age_50: 6
 
     - id: "Lived in nz for more than 10 years since age 20"
-      is_citizen_or_resident: true
-      age: 65
+      is_nz_citizen: true
       acc__is_receiving_compensation: false
       veterans_support__is_entitled_to_be_paid_veterans_pension: false
       total_number_of_years_lived_in_nz_since_age_20: 11
       total_number_of_years_lived_in_nz_since_age_50: 6
 
     - id: "Lived in nz for more than 5 years since age 50"
-      is_citizen_or_resident: true
-      age: 65
+      is_nz_citizen: true
       acc__is_receiving_compensation: false
       veterans_support__is_entitled_to_be_paid_veterans_pension: false
       total_number_of_years_lived_in_nz_since_age_20: 11
@@ -63,8 +70,10 @@
   families:
     - id: "Whanau"
       others: [
-        "Is 65 or older",
-        "Is younger than 65",
+        "Not eligible",
+        "Is citizen",
+        "Is Permanent Resident",
+        "Is Resident",
         "Is receiving compensation",
         "Is a Veteran",
         "Is a NZ Citizen",
@@ -75,8 +84,10 @@
   titled_properties:
     - id: whare
       others: [
-        "Is 65 or older",
-        "Is younger than 65",
+        "Not eligible",
+        "Is citizen",
+        "Is Permanent Resident",
+        "Is Resident",
         "Is receiving compensation",
         "Is a Veteran",
         "Is a NZ Citizen",
@@ -87,10 +98,23 @@
   output_variables:
     super__eligibility:
       2018-08:
-        - true
-        - false
-        - false
-        - true
-        - true
-        - true
-        - true
+        - false # Not eligible
+        - true # Is citizen
+        - true # Is PR
+        - true # Is resident
+        - false # Is receiving compensation
+        - true # Is a Veteran
+        - true # Is a NZ Citizen
+        - true # Lived in nz for more than 10 years since age 20
+        - true # Lived in nz for more than 5 years since age 50
+    super___eligibility_age:
+      2018-08:
+        - 0 # Not eligible
+        - 65 # Is citizen
+        - 65 # Is PR
+        - 65 # Is resident
+        - 0 # Is receiving compensation
+        - 65 # Is a Veteran
+        - 65 # Is a NZ Citizen
+        - 65 # Lived in nz for more than 10 years since age 20
+        - 65 # Lived in nz for more than 5 years since age 50

--- a/openfisca_aotearoa/variables/acts/income_tax/family_scheme/best_start.py
+++ b/openfisca_aotearoa/variables/acts/income_tax/family_scheme/best_start.py
@@ -70,8 +70,8 @@ class best_start__year_of_child(Variable):
         whatyear = whatyear * \
             (whatyear < 4) * \
             is_current_or_previous_year * \
-            (((persons("date_of_birth", period) >=
-               datetime64('2018-07-01')) + (persons("due_date_of_birth", period) >= datetime64('2018-07-01'))) > 0)
+            (((persons("date_of_birth", period)
+                >= datetime64('2018-07-01')) + (persons("due_date_of_birth", period) >= datetime64('2018-07-01'))) > 0)
 
         return whatyear
 

--- a/openfisca_aotearoa/variables/acts/income_tax/family_scheme/best_start.py
+++ b/openfisca_aotearoa/variables/acts/income_tax/family_scheme/best_start.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Import from openfisca-core the common python objects used to code the legislation in OpenFisca
 from openfisca_core.model_api import *
-# Import the entities specifically defined for this tax and benefit system
 from openfisca_aotearoa.entities import Person, Family
 from numpy import datetime64
 
@@ -16,9 +14,12 @@ class best_start__eligibility(Variable):
 
     def formula(persons, period, parameters):
         qualifies = persons("family_scheme__base_qualifies", period)
-        family_is_eligible = persons.family("best_start__family_has_children_eligible", period)
-        received_parents_allowance = persons('veterans_support__received_parents_allowance', period)
-        received_childrens_pension = persons('veterans_support__received_childrens_pension', period)
+        family_is_eligible = persons.family(
+            "best_start__family_has_children_eligible", period)
+        received_parents_allowance = persons(
+            'veterans_support__received_parents_allowance', period)
+        received_childrens_pension = persons(
+            'veterans_support__received_childrens_pension', period)
         # also does not qualify if receives
         # (i) a parental tax credit:
         # (iii) a parental leave payment or preterm baby payment under Part 7A of the Parental Leave and Employment Protection Act 1987.
@@ -34,9 +35,12 @@ class best_start__family_has_children_eligible(Variable):
     reference = "http://legislation.govt.nz/bill/government/2017/0004/15.0/DLM7512349.html"
 
     def formula(families, period, parameters):
-        families_have_children_born_after_launch_date = families.max(families.members("date_of_birth", period) >= datetime64('2018-07-01'))
-        families_have_children_due_after_launch_date = families.max(families.members("due_date_of_birth", period) >= datetime64('2018-07-01'))
-        families_have_children_younger_than_three_years = families("age_of_youngest", period) < 3
+        families_have_children_born_after_launch_date = families.max(
+            families.members("date_of_birth", period) >= datetime64('2018-07-01'))
+        families_have_children_due_after_launch_date = families.max(
+            families.members("due_date_of_birth", period) >= datetime64('2018-07-01'))
+        families_have_children_younger_than_three_years = families(
+            "age_of_youngest", period) < 3
         return ((families_have_children_born_after_launch_date + families_have_children_due_after_launch_date) > 0) * \
             families_have_children_younger_than_three_years
 
@@ -55,10 +59,12 @@ class best_start__year_of_child(Variable):
         birth_day = (birth - birth.astype('datetime64[M]') + 1).astype(int)\
 
 
-        adjust_month = birth_month + (birth_day > 1)  # adjusts month for first full month after birth
+        # adjusts month for first full month after birth
+        adjust_month = birth_month + (birth_day > 1)
         is_birthday_month_past = (adjust_month <= period.start.month)
         is_current_or_previous_year = birth_year <= period.start.year
-        whatyear = (period.start.year - birth_year) - where(is_birthday_month_past, 0, 1)
+        whatyear = (period.start.year - birth_year) - \
+            where(is_birthday_month_past, 0, 1)
 
         whatyear = whatyear + 1
         whatyear = whatyear * \
@@ -77,16 +83,21 @@ class best_start__tax_credit_per_child(Variable):
     reference = "http://legislation.govt.nz/bill/government/2017/0004/15.0/DLM7512349.html"
 
     def formula(persons, period, parameters):
-        threshold = parameters(period).entitlements.income_tax.family_scheme.best_start.full_year_abatement_threshold
-        rate = parameters(period).entitlements.income_tax.family_scheme.best_start.full_year_abatement_rate
-        prescribed_amount = parameters(period).entitlements.income_tax.family_scheme.best_start.prescribed_amount
+        threshold = parameters(
+            period).entitlements.income_tax.family_scheme.best_start.full_year_abatement_threshold
+        rate = parameters(
+            period).entitlements.income_tax.family_scheme.best_start.full_year_abatement_rate
+        prescribed_amount = parameters(
+            period).entitlements.income_tax.family_scheme.best_start.prescribed_amount
 
         # sum up families income
         # http://legislation.govt.nz/act/public/2007/0097/latest/DLM1518488.html#DLM1518488
-        family_income = persons.family.sum(persons.family.members("family_scheme__assessable_income", period.this_year))
+        family_income = persons.family.sum(persons.family.members(
+            "family_scheme__assessable_income", period.this_year))
 
         # calculate income over the threshold
-        income_over_threshold = where((family_income - threshold) < 0, 0, family_income - threshold)
+        income_over_threshold = where(
+            (family_income - threshold) < 0, 0, family_income - threshold)
 
         # work out the ages for each family member
         years = persons('best_start__year_of_child', period)
@@ -95,9 +106,11 @@ class best_start__tax_credit_per_child(Variable):
         dependant_eligible_full = (years == 1) * prescribed_amount
 
         # work out if each dependant child is eligible for abated best start tax credit
-        dependant_eligible_abated_1 = (years == 2) * (prescribed_amount - (income_over_threshold * rate))
+        dependant_eligible_abated_1 = (
+            years == 2) * (prescribed_amount - (income_over_threshold * rate))
 
-        dependant_eligible_abated_2 = (years == 3) * (prescribed_amount - (income_over_threshold * rate))
+        dependant_eligible_abated_2 = (
+            years == 3) * (prescribed_amount - (income_over_threshold * rate))
 
         # sum up the entitlement for each child
         return (dependant_eligible_full + dependant_eligible_abated_1 + dependant_eligible_abated_2) / 12

--- a/openfisca_aotearoa/variables/acts/income_tax/family_scheme/best_start.py
+++ b/openfisca_aotearoa/variables/acts/income_tax/family_scheme/best_start.py
@@ -69,8 +69,9 @@ class best_start__year_of_child(Variable):
         whatyear = whatyear + 1
         whatyear = whatyear * \
             (whatyear < 4) * \
-            is_current_or_previous_year * (((persons("date_of_birth", period) >=
-                                             datetime64('2018-07-01')) + (persons("due_date_of_birth", period) >= datetime64('2018-07-01'))) > 0)
+            is_current_or_previous_year * \
+            (((persons("date_of_birth", period) >=
+               datetime64('2018-07-01')) + (persons("due_date_of_birth", period) >= datetime64('2018-07-01'))) > 0)
 
         return whatyear
 

--- a/openfisca_aotearoa/variables/acts/super/super.py
+++ b/openfisca_aotearoa/variables/acts/super/super.py
@@ -1,25 +1,18 @@
 # -*- coding: utf-8 -*-
 
-# Import from openfisca-core the common python objects used to code the legislation in OpenFisca
 from openfisca_core.model_api import *
-# Import the entities specifically defined for this tax and entitlement system
 from openfisca_aotearoa.entities import Person
 
 
-class super__living_alone(Variable):
+class super___eligibility_age(Variable):
     value_type = int
     entity = Person
-    definition_period = MONTH
-    label = u"Is a person considered as living alone"
-    reference = "http://www.legislation.govt.nz/act/public/2001/0084/latest/whole.html#DLM5578822"
-
-
-class super__has_partner_in_long_term_care_or_rest_home(Variable):
-    value_type = bool
-    entity = Person
-    definition_period = MONTH
-    label = u"Has a partner in long term care or rest home"
+    definition_period = ETERNITY
+    label = u"The age the applicant will be eligible for NZ Super."
     reference = "http://www.legislation.govt.nz/act/public/2001/0084/latest/DLM114223.html"
+
+    def formula(persons, period, parameters):
+        return persons('super__eligibility', period) * parameters(period).general.age_of_superannuation
 
 
 class super__eligibility(Variable):
@@ -33,6 +26,6 @@ class super__eligibility(Variable):
         return persons('is_citizen_or_resident', period) *\
             not_((persons('total_number_of_years_lived_in_nz_since_age_20', period) < 10)) *\
             not_((persons('total_number_of_years_lived_in_nz_since_age_50', period) < 5)) *\
-            (persons('age', period) >= 65) *\
             not_(persons('acc__is_receiving_compensation', period)) +\
-            persons('veterans_support__is_entitled_to_be_paid_veterans_pension', period)
+            persons(
+                'veterans_support__is_entitled_to_be_paid_veterans_pension', period)

--- a/openfisca_aotearoa/variables/regulation/social_security/childcare_assistance/childcare_subsidy.py
+++ b/openfisca_aotearoa/variables/regulation/social_security/childcare_assistance/childcare_subsidy.py
@@ -43,8 +43,8 @@ class social_security__eligible_for_childcare_subsidy(Variable):
         under_6_with_disability_allowance = persons.family(
             'family_has_child_eligible_for_disability_allowance_child_under_6', period)
         return is_citizen_or_resident * is_principal_carer * \
-            (under_5_years_28_days_not_attending_school +
-             is_5_and_will_be_enrolled + under_6_with_disability_allowance)
+            (under_5_years_28_days_not_attending_school
+                + is_5_and_will_be_enrolled + under_6_with_disability_allowance)
 
 
 class family_has_resident_child_under_5_not_in_school(Variable):


### PR DESCRIPTION
* Tax and benefit system evolution.

Added `super__eligible_age`

* Technical improvement.
Removed unused/inomplete variables `super__living_alone` and `super__has_partner_in_long_term_care_or_rest_home`

* Impacted periods: all.

* Details:
  - ability to work out future eligibility for super, and obtain the person's age when they are eligible

- - - -

These changes _(remove lines which are not relevant to your contribution)_:

- Impact the OpenFisca-Aotearoa public API

Returns true to `super__eligible` if the person will be eligible at 65.

- Add a new feature
`super__eligible_age`

