### PR TITLE
Fix/entities api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# 5.1.4 - [#100](https://github.com/ServiceInnovationLab/openfisca-aotearoa/pull/100)
+* Technical improvement.
+    Pin to version 24.3.0, to ensure we support legislation explorer
+    the `/entities` route was added to the API in this version
+
 # 5.1.3 - [#94](https://github.com/ServiceInnovationLab/openfisca-aotearoa/pull/97)
 * Refactored NZ Superannuation
   - Added `super__eligible_age`

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='OpenFisca-Aotearoa',
-    version='5.1.0',
+    version='5.1.4',
     author='New Zealand Government, Service Innovation Lab',
     author_email='brenda.wallace@dia.govt.nz',
     description=u'OpenFisca tax and benefit system for Aotearoa',
@@ -16,7 +16,7 @@ setup(
     url='https://github.com/ServiceInnovationLab/openfisca-aotearoa',
     include_package_data=True,  # Will read MANIFEST.in
     install_requires=[
-        'OpenFisca-Core >= 24, < 25.0',
+        'OpenFisca-Core >= 24.3.0, < 25.0',
         ],
     extras_require={
         'test': [


### PR DESCRIPTION
### Technical improvement.

Pin to version >= 24.3.0, to ensure we support legislation explorer
the `/entities` route was added to the API in this version


The legislation explorer app is broken for NZ. It reads the `/entities` route on the API - but that just does a 404. Our openfisca version is old now, and needs upgrading to 24.3.0 or later to have this API route present.
