### PR TITLE
Removing unused variables

### DIFF
--- a/openfisca_aotearoa/variables/acts/acc/acc.py
+++ b/openfisca_aotearoa/variables/acts/acc/acc.py
@@ -6,14 +6,6 @@ from openfisca_core.model_api import *
 from openfisca_aotearoa.entities import Person
 
 
-class acc__elected_for_weekly_compensation(Variable):
-    value_type = bool
-    entity = Person
-    definition_period = MONTH
-    label = u"Person eligible and elected to receive weekly compensation instead of superannuation"
-    reference = "http://www.legislation.govt.nz/act/public/2001/0049/latest/DLM105440.html#DLM105440"
-
-
 class acc__is_receiving_compensation(Variable):
     value_type = bool
     entity = Person


### PR DESCRIPTION
* Details:
  - Removes acc__elected_for_weekly_compensation,

- - - -

These changes
- Impact the OpenFisca-Aotearoa public API
Removes variables that are not used in any calculations
These are remnants of incomplete work, and/or duplicates as a result of changing who was working on things mid-project a few too many times.