### PR TITLE
Add family_scheme__full_time_earner to minimum family tax credit in f…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 8.0.0 - [#125](https://github.com/ServiceInnovationLab/openfisca-aotearoa/pull/125)
+* Renamed variables:
+  - `family_scheme__in_work_tax_credit_is_full_time_earner` replaced with `family_scheme__full_time_earner`
+
 # 7.0.0 - [#124](https://github.com/ServiceInnovationLab/openfisca-aotearoa/pull/124)
 * Renamed variables:
   - `social_security__eligible_for_childcare_subsidy` to `social_security_regulation__eligible_for_childcare_subsidy`

--- a/openfisca_aotearoa/tests/income_tax/family_scheme/in_work_tax_credit.yaml
+++ b/openfisca_aotearoa/tests/income_tax/family_scheme/in_work_tax_credit.yaml
@@ -8,7 +8,7 @@
       family_scheme__assessable_income:
         2018: 20000
       family_scheme__in_work_tax_credit_income_under_threshold: true
-      family_scheme__in_work_tax_credit_is_full_time_earner: true
+      family_scheme__full_time_earner: true
       income_tax__residence: true
     - id: "Rakinui"
       date_of_birth: 1996-01-01
@@ -40,7 +40,7 @@
       family_scheme__assessable_income:
         2018: 20000
       family_scheme__in_work_tax_credit_income_under_threshold: true
-      family_scheme__in_work_tax_credit_is_full_time_earner: true
+      family_scheme__full_time_earner: true
       income_tax__residence: false
     - id: "Rakinui"
       date_of_birth: 1996-01-01
@@ -68,7 +68,7 @@
       family_scheme__assessable_income:
         2018: 20000
       family_scheme__in_work_tax_credit_income_under_threshold: false
-      family_scheme__in_work_tax_credit_is_full_time_earner: true
+      family_scheme__full_time_earner: true
       income_tax__residence: true
     - id: "Rakinui"
       date_of_birth: 1996-01-01
@@ -100,7 +100,7 @@
       family_scheme__assessable_income:
         2018: 20000
       family_scheme__in_work_tax_credit_income_under_threshold: true
-      family_scheme__in_work_tax_credit_is_full_time_earner: false
+      family_scheme__full_time_earner: false
       income_tax__residence: true
     - id: "Rakinui"
       date_of_birth: 1996-01-01
@@ -132,7 +132,7 @@
       family_scheme__assessable_income:
         2018: 20000
       family_scheme__in_work_tax_credit_income_under_threshold: true
-      family_scheme__in_work_tax_credit_is_full_time_earner: true
+      family_scheme__full_time_earner: true
       income_tax__residence: true
     - id: "Rakinui"
       date_of_birth: 1996-01-01
@@ -157,7 +157,7 @@
       family_scheme__assessable_income:
         2018: 20000
       family_scheme__in_work_tax_credit_income_under_threshold: true
-      family_scheme__in_work_tax_credit_is_full_time_earner: true
+      family_scheme__full_time_earner: true
       income_tax__residence: false
     - id: "Rakinui"
       date_of_birth: 1996-01-01

--- a/openfisca_aotearoa/tests/income_tax/family_scheme/minimum_family_tax_credit.yaml
+++ b/openfisca_aotearoa/tests/income_tax/family_scheme/minimum_family_tax_credit.yaml
@@ -1,4 +1,27 @@
 # We can run this test on our command line using `openfisca-run-test openfisca_aotearoa/tests/income_tax/family_scheme/minimum_family_tax_credit.yaml`
+- name: A Person qualified for the working for the minumum family tax credit
+  period: 2018-08
+  absolute_error_margin: 0
+  persons:
+    - id: "Rakinui"
+      date_of_birth: 2000-01-01
+      income_tax__residence: true
+      family_scheme__full_time_earner: true
+      veterans_support__received_parents_allowance: False
+      veterans_support__received_childrens_pension: False
+      social_security__received_income_tested_benefit:
+        2018: False
+    - id: "Tāne"
+      date_of_birth: 2012-01-01
+  families:
+    - id: "Whanau"
+      principal_caregiver: "Rakinui"
+      children: ["Tāne"]
+  titled_properties:
+    - id: "Whare"
+      owners: ["Rakinui", "Tāne"]
+  output_variables:
+    family_scheme__qualifies_for_minimum_family_tax_credit: [True, False]
 - name: A Person would be qualified for the working for the minumum family tax credit but receives a parents allowance
   period: 2018-08
   absolute_error_margin: 0
@@ -6,6 +29,7 @@
     - id: "Rakinui"
       date_of_birth: 2000-01-01
       income_tax__residence: true
+      family_scheme__full_time_earner: true
       veterans_support__received_parents_allowance: True
       veterans_support__received_childrens_pension: False
       social_security__received_income_tested_benefit:
@@ -28,7 +52,31 @@
     - id: "Rakinui"
       date_of_birth: 2000-01-01
       income_tax__residence: true
+      family_scheme__full_time_earner: true
       veterans_support__received_parents_allowance: True
+      veterans_support__received_childrens_pension: False
+      social_security__received_income_tested_benefit:
+        2018: False
+    - id: "Tāne"
+      date_of_birth: 2012-01-01
+  families:
+    - id: "Whanau"
+      principal_caregiver: "Rakinui"
+      children: ["Tāne"]
+  titled_properties:
+    - id: "Whare"
+      owners: ["Rakinui", "Tāne"]
+  output_variables:
+    family_scheme__qualifies_for_minimum_family_tax_credit: [False, False]
+- name: A Person would be qualified for the working for the minumum family tax credit but is not a full time earner
+  period: 2018-08
+  absolute_error_margin: 0
+  persons:
+    - id: "Rakinui"
+      date_of_birth: 2000-01-01
+      income_tax__residence: true
+      family_scheme__full_time_earner: false
+      veterans_support__received_parents_allowance: False
       veterans_support__received_childrens_pension: False
       social_security__received_income_tested_benefit:
         2018: False

--- a/openfisca_aotearoa/variables/acts/income_tax/family_scheme/in_work_tax_credit.py
+++ b/openfisca_aotearoa/variables/acts/income_tax/family_scheme/in_work_tax_credit.py
@@ -9,7 +9,7 @@ class family_scheme__qualifies_for_in_work_tax_credit(Variable):
     entity = Person
     definition_period = MONTH
     label = u'Is a person is qualified as eligible for the in-work tax credit'
-    reference = "http://www.legislation.govt.nz/act/public/2007/0097/latest/DLM1518484.html"
+    reference = "http://www.legislation.govt.nz/act/public/2007/0097/latest/DLM1518522.html"
 
     def formula(persons, period, parameters):
         base_qualifies = persons("family_scheme__base_qualifies", period)
@@ -19,7 +19,7 @@ class family_scheme__qualifies_for_in_work_tax_credit(Variable):
 
         return base_qualifies * not_(received_tested_benefit) * not_(received_parents_allowance) \
             * not_(received_childrens_pension) * persons('family_scheme__in_work_tax_credit_income_under_threshold', period) \
-            * persons('family_scheme__in_work_tax_credit_is_full_time_earner', period)
+            * persons('family_scheme__full_time_earner', period)
 
 
 class family_scheme__in_work_tax_credit_income_under_threshold(Variable):  # this variable is a proxy for the calculation "family_scheme__in_work_tax_credit_entitlement" which needs to be coded
@@ -28,14 +28,6 @@ class family_scheme__in_work_tax_credit_income_under_threshold(Variable):  # thi
     definition_period = MONTH
     label = u'Is the income under the threshold for the in work tax credit'
     reference = "http://www.legislation.govt.nz/act/public/2007/0097/latest/DLM1518484.html"
-
-
-class family_scheme__in_work_tax_credit_is_full_time_earner(Variable):
-    value_type = bool
-    entity = Person
-    definition_period = MONTH
-    label = u'Is the income under the threshold for the in work tax credit'
-    reference = "http://www.legislation.govt.nz/act/public/2007/0097/latest/DLM1518419.html"
 
 
 class family_scheme__in_work_tax_credit_entitlement(Variable):

--- a/openfisca_aotearoa/variables/acts/income_tax/family_scheme/minimum_family_tax_credit.py
+++ b/openfisca_aotearoa/variables/acts/income_tax/family_scheme/minimum_family_tax_credit.py
@@ -9,12 +9,13 @@ class family_scheme__qualifies_for_minimum_family_tax_credit(Variable):
     entity = Person
     definition_period = MONTH
     label = u'Is a person is qualified as eligible for the minimum family tax credit'
-    reference = "http://www.legislation.govt.nz/act/public/2007/0097/latest/DLM1518484.html"
+    reference = "http://www.legislation.govt.nz/act/public/2007/0097/latest/DLM1518564.html"
 
     def formula(persons, period, parameters):
         base_qualifies = persons("family_scheme__base_qualifies", period)
         received_tested_benefit = persons('social_security__received_income_tested_benefit', period.this_year)
         received_parents_allowance = persons('veterans_support__received_parents_allowance', period)
         received_childrens_pension = persons('veterans_support__received_childrens_pension', period)
+        full_time_earner = persons("family_scheme__full_time_earner", period)
 
-        return base_qualifies * not_(received_tested_benefit) * not_(received_parents_allowance) * not_(received_childrens_pension)
+        return base_qualifies * full_time_earner * not_(received_tested_benefit) * not_(received_parents_allowance) * not_(received_childrens_pension)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='OpenFisca-Aotearoa',
-    version='7.0.0',
+    version='8.0.0',
     author='New Zealand Government, Service Innovation Lab',
     author_email='brenda.wallace@dia.govt.nz',
     description=u'OpenFisca tax and benefit system for Aotearoa',


### PR DESCRIPTION
* Tax and benefit system evolution. | Technical improvement. 
* Impacted periods: all.
* Impacted areas: ` openfisca_aotearoa/variables/acts/income_tax/family_scheme/`
* Details:
  - Renamed `family_scheme__in_work_tax_credit_is_full_time_earner` to `family_scheme__full_time_earner`
  - Applied `family_scheme__full_time_earner` to `family_scheme__qualifies_for_minimum_family_tax_credit`

- - - -

These change:

- Impact the OpenFisca-Aotearoa public API (for instance renaming or removing a variable)
- Add a new feature (for instance adding a variable)
- Fix or improve an already existing calculation.
- Change non-functional parts of this repository (for instance editing the README)
