### PR TITLE
Revert "Bump dpath from 1.4.0 to 1.4.2"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 
 # Core's dependencies
 Biryani[datetimeconv] >= 0.10.8
-dpath ==1.4.2
+dpath == 1.4.0
 enum34 >= 1.1.6
 future < 1.0.0
 numpy >= 1.11, < 1.16


### PR DESCRIPTION
Reverts ServiceInnovationLab/openfisca-aotearoa#109
This broke - the new dpath won't build on heroku.

I manually rolled back production to before this change, and this PR does the same to git master

the erros on production were:

```

2019-02-12T00:18:37.135443+00:00 heroku[web.1]: Starting process with command `SERVER_NAME=openfisca-aotearoa.herokuapp.com openfisca serve --country-package openfisca_aotearoa --port 47619 --bind 0.0.0.0:47619`
2019-02-12T00:18:39.823812+00:00 heroku[web.1]: State changed from starting to crashed
2019-02-12T00:18:39.809964+00:00 heroku[web.1]: Process exited with status 1
2019-02-12T00:18:39.700866+00:00 app[web.1]: Traceback (most recent call last):
2019-02-12T00:18:39.700894+00:00 app[web.1]: File "/app/.heroku/python/lib/python3.7/site-packages/pkg_resources/__init__.py", line 574, in _build_master
2019-02-12T00:18:39.701331+00:00 app[web.1]: ws.require(__requires__)
2019-02-12T00:18:39.701337+00:00 app[web.1]: File "/app/.heroku/python/lib/python3.7/site-packages/pkg_resources/__init__.py", line 892, in require
2019-02-12T00:18:39.701823+00:00 app[web.1]: needed = self.resolve(parse_requirements(requirements))
2019-02-12T00:18:39.701826+00:00 app[web.1]: File "/app/.heroku/python/lib/python3.7/site-packages/pkg_resources/__init__.py", line 783, in resolve
2019-02-12T00:18:39.702321+00:00 app[web.1]: raise VersionConflict(dist, req).with_context(dependent_req)
2019-02-12T00:18:39.702408+00:00 app[web.1]: pkg_resources.ContextualVersionConflict: (dpath 1.4.2 (/app/.heroku/python/lib/python3.7/site-packages), Requirement.parse('dpath==1.4.0'), {'OpenFisca-Core'})
2019-02-12T00:18:39.702411+00:00 app[web.1]: 
2019-02-12T00:18:39.702412+00:00 app[web.1]: During handling of the above exception, another exception occurred:
2019-02-12T00:18:39.702413+00:00 app[web.1]: 
2019-02-12T00:18:39.702414+00:00 app[web.1]: Traceback (most recent call last):
2019-02-12T00:18:39.702415+00:00 app[web.1]: File "/app/.heroku/python/bin/openfisca", line 6, in <module>
2019-02-12T00:18:39.702569+00:00 app[web.1]: from pkg_resources import load_entry_point
2019-02-12T00:18:39.702573+00:00 app[web.1]: File "/app/.heroku/python/lib/python3.7/site-packages/pkg_resources/__init__.py", line 3088, in <module>
2019-02-12T00:18:39.703630+00:00 app[web.1]: @_call_aside
2019-02-12T00:18:39.703634+00:00 app[web.1]: File "/app/.heroku/python/lib/python3.7/site-packages/pkg_resources/__init__.py", line 3072, in _call_aside
2019-02-12T00:18:39.704665+00:00 app[web.1]: f(*args, **kwargs)
2019-02-12T00:18:39.704669+00:00 app[web.1]: File "/app/.heroku/python/lib/python3.7/site-packages/pkg_resources/__init__.py", line 3101, in _initialize_master_working_set
2019-02-12T00:18:39.705717+00:00 app[web.1]: working_set = WorkingSet._build_master()
2019-02-12T00:18:39.705720+00:00 app[web.1]: File "/app/.heroku/python/lib/python3.7/site-packages/pkg_resources/__init__.py", line 576, in _build_master
2019-02-12T00:18:39.705996+00:00 app[web.1]: return cls._build_from_requirements(__requires__)
2019-02-12T00:18:39.705997+00:00 app[web.1]: File "/app/.heroku/python/lib/python3.7/site-packages/pkg_resources/__init__.py", line 589, in _build_from_requirements
2019-02-12T00:18:39.706297+00:00 app[web.1]: dists = ws.resolve(reqs, Environment())
2019-02-12T00:18:39.706301+00:00 app[web.1]: File "/app/.heroku/python/lib/python3.7/site-packages/pkg_resources/__init__.py", line 778, in resolve
2019-02-12T00:18:39.706640+00:00 app[web.1]: raise DistributionNotFound(req, requirers)
2019-02-12T00:18:39.706717+00:00 app[web.1]: pkg_resources.DistributionNotFound: The 'dpath==1.4.0' distribution was not found and is required by OpenFisca-Core
2019-02-12T00:18:42.358261+00:00 heroku[router]: at=error code=H10 desc="App crashed" method=GET path="/" host=openfisca-aotearoa.herokuapp.com request_id=6651c9c2-d59e-4ac3-b2c3-c826c8462d0d fwd="203.171.33.130" dyno= connect= service= status=503 bytes= protocol=https
2019-02-12T00:18:45.000000+00:00 app[api]: Build succeeded
2019-02-12T00:18:56.486989+00:00 heroku[router]: at=error code=H10 desc="App crashed" method=GET path="/variable/is_in_de_facto_relationship" host=api.rules.nz request_id=775ef377-1840-4a17-95e0-6310e07bd5c2 fwd="66.249.66.213" dyno= connect= service= status=503 bytes= protocol=https
```