### PR TITLE
Indentation fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,8 +87,8 @@ jobs:
     steps:
       - checkout
       - run:
-        name: "git tag the release"
-        command: "./.circleci/git_tag.sh"
+          name: "git tag the release"
+          command: "./.circleci/git_tag.sh"
 
 workflows:
   version: 2


### PR DESCRIPTION
* Crash fix.

Fix indentation error on circleci

Fixes:
```
Build-agent version 1.0.9008-0abaa7b9 (2019-03-13T15:08:16+0000)
Configuration errors: 1 error occurred:

* In step 2 definition: Step

  - run: 
    command: ./.circleci/git_tag.sh
    name: git tag the release

has incorrect indentation, it should be formatted like:

  - step:
      option1: value
      option2: value
```

https://circleci.com/gh/ServiceInnovationLab/openfisca-aotearoa/2734
