### PR TITLE
Fix/dupes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# 11.1.1 [167](https://github.com/ServiceInnovationLab/openfisca-aotearoa/pull/167)
+* Rename duplicate tests (same name, different test)
+
 # 11.1.0 [167](https://github.com/ServiceInnovationLab/openfisca-aotearoa/pull/167)
 * Adds values for Rates Rebates 2018 to 2019
 

--- a/openfisca_aotearoa/tests/income_tax/family_scheme/best_start.yaml
+++ b/openfisca_aotearoa/tests/income_tax/family_scheme/best_start.yaml
@@ -129,7 +129,8 @@
       2018-07: [0, 0, 0, 260]
     best_start__entitlement:
       2018-07: [260, 0, 0, 0]
-- name: Tests Best Start entitlement value with baby due date after 1st July 2018
+
+- name: Tests Best Start entitlement value with baby due date after 1st July 2018 with older sibling
   period: 2018
   absolute_error_margin: 0
   input:
@@ -159,7 +160,8 @@
       2018-07: [0, 0, 0, 260 ]
     best_start__entitlement:
       2018-07: [260, 0, 0, 0]
-- name: Tests Best Start entitlement value with baby due date after 1st July 2018
+
+- name: Tests Best Start entitlement value with baby due date after 1st July 2018 with younger sibling
   period: 2018
   absolute_error_margin: 0
   input:

--- a/openfisca_aotearoa/tests/income_tax/family_scheme/family_tax_credit.yaml
+++ b/openfisca_aotearoa/tests/income_tax/family_scheme/family_tax_credit.yaml
@@ -59,7 +59,8 @@
         others: ["Papatūānuku", "Rakinui", "Tāne", "Rongo", "Ikatere"]
   output:
     family_scheme__qualifies_for_family_tax_credit: [0, 0, 0, 0, 0]
-- name: Family tax credit - too much income
+
+- name: Family tax credit - solo parent with too much income
   period: 2018-08
   absolute_error_margin: 0
   input:
@@ -79,7 +80,7 @@
       2018-08:
         - false
 
-- name: Family tax credit - too much income
+- name: Family tax credit - couple with too much income
   period: 2018-08
   absolute_error_margin: 0
   input:

--- a/openfisca_aotearoa/tests/income_tax/family_scheme/in_work_tax_credit.yaml
+++ b/openfisca_aotearoa/tests/income_tax/family_scheme/in_work_tax_credit.yaml
@@ -1,6 +1,6 @@
 # We can run this test on our command line using `openfisca-run-test openfisca_aotearoa/tests/income_tax/family_scheme/in_work_tax_credit.yaml`
 
-- name: Tests persons age eligibility in relation to the in work tax credit
+- name: Family age eligibility in relation to the in work tax credit
   period: 2018-08
   input:
     persons:

--- a/openfisca_aotearoa/tests/income_tax/family_scheme/minimum_family_tax_credit.yaml
+++ b/openfisca_aotearoa/tests/income_tax/family_scheme/minimum_family_tax_credit.yaml
@@ -22,26 +22,3 @@
         owners: ["Rakinui", "Tāne"]
   output:
     family_scheme__qualifies_for_minimum_family_tax_credit: [False, False]
-- name: A Person would be qualified for the working for the minumum family tax credit but receives a parents allowance
-  period: 2018-08
-  absolute_error_margin: 0
-  input:
-    persons:
-      "Rakinui":
-        date_of_birth: 2000-01-01
-        income_tax__residence: true
-        veterans_support__received_parents_allowance: True
-        veterans_support__received_childrens_pension: False
-        social_security__received_income_tested_benefit:
-          2018: False
-      "Tāne":
-        date_of_birth: 2012-01-01
-    families:
-      Whanau:
-        principal_caregiver: "Rakinui"
-        children: ["Tāne"]
-    titled_properties:
-      Whare:
-        owners: ["Rakinui", "Tāne"]
-  output:
-    family_scheme__qualifies_for_minimum_family_tax_credit: [False, False]

--- a/openfisca_aotearoa/tests/rates_rebates/rates_rebates_2018.yaml
+++ b/openfisca_aotearoa/tests/rates_rebates/rates_rebates_2018.yaml
@@ -44,7 +44,7 @@
     rates_rebates__rates_total: 2400
   output:
     rates_rebates__maximum_income_for_full_rebate: 33276
-- name: Proof of maximum income required for the full rebate with 3 dependants and rates of $2400
+- name: Calculate rebate for the full rebate with 3 dependants and rates of $2400
   period: 2018
   absolute_error_margin: 1.0
   input:
@@ -53,7 +53,7 @@
     rates_rebates__rates_total: 2400
   output:
     rates_rebates__rebate: 620
-- name: Proof of maximum income required for the full rebate with 3 dependants and rates of $2400
+- name: Expect full rebate with 3 dependants and rates of $2400
   period: 2018
   absolute_error_margin: 0.5
   input:

--- a/openfisca_aotearoa/tests/rates_rebates/rates_rebates_2019.yaml
+++ b/openfisca_aotearoa/tests/rates_rebates/rates_rebates_2019.yaml
@@ -1,4 +1,4 @@
-- name: Someone earning 32103 with no dependants and rates of 2000
+- name: Input/output test of earning 32103 with no dependants and rates of 2000
   period: 2018
   absolute_error_margin: 1.0
   input:
@@ -9,7 +9,7 @@
     rates_rebates__rebate: 312.67
 
 
-- name: Someone earning 32103 with no dependants and rates of 2000
+- name: Family scenario of earning 32103 with no dependants and rates of 2000
   period: 2018
   absolute_error_margin: 1.0
   input:

--- a/openfisca_aotearoa/tests/social_security/community_services_card.yaml
+++ b/openfisca_aotearoa/tests/social_security/community_services_card.yaml
@@ -159,7 +159,7 @@
       - true  # mama
 
 
-- name: Community Services Card - not eligible if above threshold
+- name: Community Services Card - Super, but not eligible if above threshold
   period: 2018-08
   absolute_error_margin: 0
   input:
@@ -260,7 +260,7 @@
       - true  # mama
 
 
-- name: Community Services Card - not eligible if above threshold
+- name: Community Services Card - Student but not eligible if above threshold
   period: 2018-08
   absolute_error_margin: 0
   input:

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='OpenFisca-Aotearoa',
-    version='11.1.0',
+    version='11.1.1',
     author='New Zealand Government, Service Innovation Lab',
     author_email='brenda.wallace@dia.govt.nz,hamish.fraser@dia.govt.nz',
     description=u'OpenFisca tax and benefit system for Aotearoa',


### PR DESCRIPTION
When preparing to show tests on https://rules.nz, we found many tests with duplicate names

I've added more details to their names and removed one that was completely duplicated.
