### PR TITLE
Removing unnecesary family/titled_property groups in tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,10 +92,12 @@ jobs:
 
 workflows:
   version: 2
-  build_and_test:
+  lint:
     jobs:
       - pythonlint
       - yamllint
+  build_and_test:
+    jobs:
       - version-bump
       - build_python3
       - tag_release:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
-# 11.1.1 [167](https://github.com/ServiceInnovationLab/openfisca-aotearoa/pull/167)
+# 11.1.2 [167](https://github.com/ServiceInnovationLab/openfisca-aotearoa/pull/170)
+*  Removing unnecesary family/titled_property groups in tests
+
+# 11.1.1 [167](https://github.com/ServiceInnovationLab/openfisca-aotearoa/pull/169)
 * Rename duplicate tests (same name, different test)
 
 # 11.1.0 [167](https://github.com/ServiceInnovationLab/openfisca-aotearoa/pull/167)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 
-# 11.1.2 [167](https://github.com/ServiceInnovationLab/openfisca-aotearoa/pull/170)
-*  Removing unnecesary family/titled_property groups in tests
+# 11.1.2 [170](https://github.com/ServiceInnovationLab/openfisca-aotearoa/pull/170)
+* No functional changes.
+  - Removing unnecesary family/titled_property groups in tests
 
-# 11.1.1 [167](https://github.com/ServiceInnovationLab/openfisca-aotearoa/pull/169)
+# 11.1.1 [169](https://github.com/ServiceInnovationLab/openfisca-aotearoa/pull/169)
 * Rename duplicate tests (same name, different test)
 
 # 11.1.0 [167](https://github.com/ServiceInnovationLab/openfisca-aotearoa/pull/167)

--- a/openfisca_aotearoa/tests/citizenship/citizenship_adding_days.yaml
+++ b/openfisca_aotearoa/tests/citizenship/citizenship_adding_days.yaml
@@ -19,13 +19,6 @@
           "2015-01-04": true
           "2015-01-05": true
           "2015-01-06": false
-
-    families:
-      "Whanau":
-        others: ["Tahi"]
-    titled_properties:
-      whare:
-        others: ["Tahi"]
   output:
     days_present_in_new_zealand_in_preceeding_year:
       "2014-12-30": 0

--- a/openfisca_aotearoa/tests/citizenship/citizenship_leap_days.yaml
+++ b/openfisca_aotearoa/tests/citizenship/citizenship_leap_days.yaml
@@ -9,12 +9,6 @@
           "2001-01-01": true
         immigration__entitled_to_indefinite_stay:
           "2001-01-01": true
-    families:
-      "Whanau":
-        others: ["Tahi"]
-    titled_properties:
-      whare:
-        others: ["Tahi"]
   output:
     days_present_in_new_zealand_in_preceeding_year:
       "2014-02-28": 365

--- a/openfisca_aotearoa/tests/citizenship/citizenship_more.yaml
+++ b/openfisca_aotearoa/tests/citizenship/citizenship_more.yaml
@@ -36,12 +36,6 @@
           "2017-06-20": true
           "2018-01-21": false
           "2018-02-12": true
-    families:
-      "Whanau":
-        others: ["ruby_2017-10-01"]
-    titled_properties:
-      whare:
-        others: ["ruby_2017-10-01"]
   output:
     # citizenship__meets_minimum_presence_requirements:
     #   "2017-10-01": true

--- a/openfisca_aotearoa/tests/citizenship/citizenship_presence.yaml
+++ b/openfisca_aotearoa/tests/citizenship/citizenship_presence.yaml
@@ -18,12 +18,6 @@
         immigration__entitled_to_indefinite_stay:
           "2015-01-01": true
           "2021-08-29": false
-    families:
-      "Whanau":
-        others: ["Tahi"]
-    titled_properties:
-      whare:
-        others: ["Tahi"]
   output:
     citizenship__citizenship_by_grant_may_be_authorized:
       "2019-01-01": false

--- a/openfisca_aotearoa/tests/immigration/indefinite_stay_basic.yaml
+++ b/openfisca_aotearoa/tests/immigration/indefinite_stay_basic.yaml
@@ -7,12 +7,6 @@
           "2001-01-01": true
         immigration__entitled_to_indefinite_stay:
           "2001-01-01": true
-    families:
-      "Whanau":
-        others: [ Tahi ]
-    titled_properties:
-      whare:
-        others: [ Tahi ]
   output:
     was_present_in_nz_and_entitled_to_indefinite_stay:
       "2001-01-01": true

--- a/openfisca_aotearoa/tests/immigration/indefinite_stay_enter_and_leave.yaml
+++ b/openfisca_aotearoa/tests/immigration/indefinite_stay_enter_and_leave.yaml
@@ -17,12 +17,6 @@
           "2013-05-05": true
           "2015-06-20": false
           "2015-07-01": true
-    families:
-      "Whanau":
-        others: ["Tahi"]
-    titled_properties:
-      whare:
-        others: ["Tahi"]
   output:
     was_present_in_nz_and_entitled_to_indefinite_stay:
       "2000-12-31": false

--- a/openfisca_aotearoa/tests/immigration/indefinite_stay_present_not_entitled.yaml
+++ b/openfisca_aotearoa/tests/immigration/indefinite_stay_present_not_entitled.yaml
@@ -16,12 +16,6 @@
           "2013-02-10": true
           "2015-02-20": false
           "2015-03-15": true
-    families:
-      "Whanau":
-        others: ["Tahi"]
-    titled_properties:
-      whare:
-        others: ["Tahi"]
   output:
     was_present_in_nz_and_entitled_to_indefinite_stay:
       "2000-12-01": false

--- a/openfisca_aotearoa/tests/immigration/residence_for_benefits.yaml
+++ b/openfisca_aotearoa/tests/immigration/residence_for_benefits.yaml
@@ -27,19 +27,14 @@
         immigration__is_protected_person: true
         social_security__has_resided_continuously_in_nz_for_a_period_of_at_least_2_years_at_any_one_time: false
     families:
-      Whanau_tahi:
+      whānau_tahi:
         principal_caregiver: Mama
         children:
           - Tama
           - Tamahine
         others:
           - Papa
-      Whanau_rua:
-        others: [Mary, Barry, Larry]
-    titled_properties:
-      whare:
-        others: [Mama, Papa, Tama, Tamahine]
-      home:
+      whānau_rua:
         others: [Mary, Barry, Larry]
   output:
     is_nz_citizen:

--- a/openfisca_aotearoa/tests/immigration/residence_for_benefits.yaml
+++ b/openfisca_aotearoa/tests/immigration/residence_for_benefits.yaml
@@ -26,16 +26,6 @@
       Larry:
         immigration__is_protected_person: true
         social_security__has_resided_continuously_in_nz_for_a_period_of_at_least_2_years_at_any_one_time: false
-    families:
-      whānau_tahi:
-        principal_caregiver: Mama
-        children:
-          - Tama
-          - Tamahine
-        others:
-          - Papa
-      whānau_rua:
-        others: [Mary, Barry, Larry]
   output:
     is_nz_citizen:
       - false # mama

--- a/openfisca_aotearoa/tests/income_tax/family_scheme/best_start.yaml
+++ b/openfisca_aotearoa/tests/income_tax/family_scheme/best_start.yaml
@@ -48,23 +48,6 @@
         principal_caregiver: "Papatūānuku-3"
         partners: ["Samuel"]
         children: ["Hemi-junior-early"]
-    titled_properties:
-      "Earth":
-        others:
-          - "Papatūānuku"
-          - "Rakinui"
-          - "Tāne"
-          - "Rongo"
-          - "Ikatere"
-          - "Tāwhirimātea"
-          - "Papatūānuku-2"
-          - "Papatūānuku-3"
-          - "Tāne-2"
-          - "Samuel"
-          - "Rongo-2"
-          - "Hemi"
-          - "Hemi-junior"
-          - "Hemi-junior-early"
   output:
     best_start__family_has_children_eligible:
       2018-07: [0, 1, 1]
@@ -93,9 +76,6 @@
         principal_caregiver: "Papatūānuku"
         partners: ["Rakinui"]
         children: ["Hemi-junior-early"]
-    titled_properties:
-      "Earth":
-        others: ["Papatūānuku", "Rakinui", "Hemi-junior-early"]
   output:
     best_start__family_has_children_eligible:
       2018-07: [1]
@@ -121,9 +101,6 @@
         principal_caregiver: "Papatūānuku"
         partners: ["Rakinui"]
         children: ["Hemi-junior", "Hemi-junior-early"]
-    titled_properties:
-      "Earth":
-        others: ["Papatūānuku", "Rakinui", "Hemi-junior", "Hemi-junior-early"]
   output:
     best_start__tax_credit_per_child:
       2018-07: [0, 0, 0, 260]
@@ -151,9 +128,6 @@
         principal_caregiver: "Papatūānuku"
         partners: ["Rakinui"]
         children: ["Hemi-junior", "Hemi-junior-early"]
-    titled_properties:
-      "Earth":
-        others: ["Papatūānuku", "Rakinui", "Hemi-junior", "Hemi-junior-early"]
   output:
     best_start__tax_credit_per_child:
       2018-07: [0, 0, 0, 260 ]
@@ -184,9 +158,6 @@
         principal_caregiver: "Papatūānuku"
         partners: ["Rakinui"]
         children: ["Hemi-junior", "Hemi-junior-early"]
-    titled_properties:
-      "Earth":
-        others: ["Papatūānuku", "Rakinui", "Hemi-junior", "Hemi-junior-early"]
   output:
     best_start__tax_credit_per_child:
       2019-04: [0, 0, 0, 260 ]

--- a/openfisca_aotearoa/tests/income_tax/family_scheme/eligibility.yaml
+++ b/openfisca_aotearoa/tests/income_tax/family_scheme/eligibility.yaml
@@ -11,9 +11,6 @@
     families:
       Whanau:
         partners: ["Papatūānuku", "Rakinui"]
-    titled_properties:
-      Whare:
-        owners: ["Papatūānuku", "Rakinui"]
   output:
     family_scheme__caregiver_age_qualifies: [False, True]
 - name: A Person is qualified as a principal caregiver for the family scheme
@@ -32,9 +29,6 @@
         principal_caregiver: "Papatūānuku"
         partners: ["Rakinui"]
         children: ["Tāne"]
-    titled_properties:
-      Whare:
-        owners: ["Papatūānuku", "Rakinui", "Tāne"]
   output:
     family_scheme__qualifies_as_principal_carer: [True, False, False]
 - name: A Person is qualified as a income tax residence for the family scheme
@@ -101,9 +95,6 @@
       Whanau:
         principal_caregiver: "Rakinui"
         children: ["Tāne"]
-    titled_properties:
-      Whare:
-        owners: ["Rakinui", "Tāne"]
   output:
     family_scheme__qualifies_for_working_for_families: [True, False]
 - name: A Person would be qualified for working for families but gets veterans support parent allowance
@@ -124,9 +115,6 @@
       Whanau:
         principal_caregiver: "Rakinui"
         children: ["Tāne"]
-    titled_properties:
-      Whare:
-        owners: ["Rakinui", "Tāne"]
   output:
     family_scheme__qualifies_for_working_for_families: [False, False]
 - name: A Person would be qualified for the working for families tax credit but gets a childrens pension
@@ -147,9 +135,6 @@
       Whanau:
         principal_caregiver: "Rakinui"
         children: ["Tāne"]
-    titled_properties:
-      Whare:
-        owners: ["Rakinui", "Tāne"]
   output:
     family_scheme__qualifies_for_working_for_families: [False, False]
 - name: A Person would be qualified for the working for in-work tax credit but receives an income tested benefit
@@ -170,8 +155,5 @@
       Whanau:
         principal_caregiver: "Rakinui"
         children: ["Tāne"]
-    titled_properties:
-      Whare:
-        owners: ["Rakinui", "Tāne"]
   output:
     family_scheme__qualifies_for_in_work_tax_credit: [False, False]

--- a/openfisca_aotearoa/tests/income_tax/family_scheme/family_scheme.yaml
+++ b/openfisca_aotearoa/tests/income_tax/family_scheme/family_scheme.yaml
@@ -12,9 +12,6 @@
       "First family":
         principal_caregiver: "Papatūānuku"
         partners: ["Rakinui"]
-    titled_properties:
-      "Earth":
-        owners: ["Papatūānuku", "Rakinui"]
   output:
     family_scheme__caregiver_age_qualifies:
       2018-07: [0, 1]
@@ -31,9 +28,6 @@
       "First family":
         principal_caregiver: "Papatūānuku"
         children: ["Hemi"]
-    titled_properties:
-      "Earth":
-        owners: ["Papatūānuku", "Hemi"]
   output:
     family_scheme__has_dependent_children:
       2018-07: [1]
@@ -56,9 +50,6 @@
       Whanau:
         principal_caregiver: "Papatūānuku"
         children: ["Hemi", "Tāne", "Rongo", "Ikatere"]
-    titled_properties:
-      Whare:
-        others: ["Papatūānuku", "Hemi", "Tāne", "Rongo", "Ikatere"]
   output:
     family_scheme__has_dependent_children:
       2018-07: [1]

--- a/openfisca_aotearoa/tests/income_tax/family_scheme/family_tax_credit.yaml
+++ b/openfisca_aotearoa/tests/income_tax/family_scheme/family_tax_credit.yaml
@@ -24,9 +24,6 @@
         principal_caregiver: "Papatūānuku"
         partners: ["Rakinui"]
         children: ["Tāne", "Rongo", "Ikatere"]
-    titled_properties:
-      Whare:
-        others: ["Papatūānuku", "Rakinui", "Tāne", "Rongo", "Ikatere"]
   output:
     family_scheme__qualifies_for_family_tax_credit: [1, 0, 0, 0, 0]
 - name: Tests persons income over threshold and not elible for family tax credit
@@ -54,9 +51,6 @@
         principal_caregiver: "Papatūānuku"
         partners: ["Rakinui"]
         children: ["Tāne", "Rongo", "Ikatere"]
-    titled_properties:
-      Whare:
-        others: ["Papatūānuku", "Rakinui", "Tāne", "Rongo", "Ikatere"]
   output:
     family_scheme__qualifies_for_family_tax_credit: [0, 0, 0, 0, 0]
 - name: Family tax credit - too much income
@@ -71,9 +65,6 @@
     families:
       Whanau:
         principal_caregiver: "Papatūānuku"
-    titled_properties:
-      Whare:
-        others: ["Papatūānuku"]
   output:
     family_scheme__qualifies_for_family_tax_credit:
       2018-08:
@@ -96,9 +87,6 @@
       Whanau:
         principal_caregiver: "Papatūānuku"
         partners: ["Rakinui"]
-    titled_properties:
-      Whare:
-        others: ["Papatūānuku", "Rakinui"]
   output:
     family_scheme__qualifies_for_family_tax_credit:
       2018-08:

--- a/openfisca_aotearoa/tests/income_tax/family_scheme/in_work_tax_credit.yaml
+++ b/openfisca_aotearoa/tests/income_tax/family_scheme/in_work_tax_credit.yaml
@@ -27,9 +27,6 @@
         principal_caregiver: "Papatūānuku"
         partners: ["Rakinui"]
         children: ["Tāne", "Rongo", "Ikatere"]
-    titled_properties:
-      "Whare":
-        others: ["Papatūānuku", "Rakinui", "Tāne", "Rongo", "Ikatere"]
   output:
     family_scheme__qualifies_for_in_work_tax_credit: [1, 0, 0, 0, 0]
 
@@ -56,9 +53,6 @@
         principal_caregiver: "Papatūānuku"
         partners: ["Rakinui"]
         children: ["Tāne"]
-    titled_properties:
-      "Whare":
-        others: ["Papatūānuku", "Rakinui", "Tāne"]
   output:
     family_scheme__qualifies_for_in_work_tax_credit: [0, 0, 0]
 
@@ -89,9 +83,6 @@
         principal_caregiver: "Papatūānuku"
         partners: ["Rakinui"]
         children: ["Tāne", "Rongo", "Ikatere"]
-    titled_properties:
-      "Whare":
-        others: ["Papatūānuku", "Rakinui", "Tāne", "Rongo", "Ikatere"]
   output:
     family_scheme__qualifies_for_in_work_tax_credit: [0, 0, 0, 0, 0]
 
@@ -122,9 +113,6 @@
         principal_caregiver: "Papatūānuku"
         partners: ["Rakinui"]
         children: ["Tāne", "Rongo", "Ikatere"]
-    titled_properties:
-      "Whare":
-        others: ["Papatūānuku", "Rakinui", "Tāne", "Rongo", "Ikatere"]
   output:
     family_scheme__qualifies_for_in_work_tax_credit: [0, 0, 0, 0, 0]
 
@@ -148,9 +136,6 @@
       "Whanau":
         principal_caregiver: "Papatūānuku"
         partners: ["Rakinui"]
-    titled_properties:
-      "Whare":
-        others: ["Papatūānuku", "Rakinui"]
   output:
     family_scheme__qualifies_for_in_work_tax_credit: [0, 0]
 
@@ -177,8 +162,5 @@
         principal_caregiver: "Papatūānuku"
         partners: ["Rakinui"]
         children: ["Tāne"]
-    titled_properties:
-      "Whare":
-        others: ["Papatūānuku", "Rakinui", "Tāne"]
   output:
     family_scheme__qualifies_for_in_work_tax_credit: [0, 0, 0]

--- a/openfisca_aotearoa/tests/income_tax/family_scheme/minimum_family_tax_credit.yaml
+++ b/openfisca_aotearoa/tests/income_tax/family_scheme/minimum_family_tax_credit.yaml
@@ -17,9 +17,6 @@
       Whanau:
         principal_caregiver: "Rakinui"
         children: ["Tāne"]
-    titled_properties:
-      Whare:
-        owners: ["Rakinui", "Tāne"]
   output:
     family_scheme__qualifies_for_minimum_family_tax_credit: [False, False]
 - name: A Person would be qualified for the working for the minumum family tax credit but receives a parents allowance
@@ -40,8 +37,5 @@
       Whanau:
         principal_caregiver: "Rakinui"
         children: ["Tāne"]
-    titled_properties:
-      Whare:
-        owners: ["Rakinui", "Tāne"]
   output:
     family_scheme__qualifies_for_minimum_family_tax_credit: [False, False]

--- a/openfisca_aotearoa/tests/parental_leave/parental_leave.yaml
+++ b/openfisca_aotearoa/tests/parental_leave/parental_leave.yaml
@@ -43,10 +43,6 @@
     families:
       Whanau:
         others: [Passes_employee_test, Non_Citizen, A_Primary_Carer, Not_A_Primary_Carer, Received_Parental_Leave]
-    titled_properties:
-      whare:
-        others: [Passes_employee_test, Non_Citizen, A_Primary_Carer, Not_A_Primary_Carer, Received_Parental_Leave]
-
   output:
     parental_leave__eligible_employee:
       - false   # Passes employee test

--- a/openfisca_aotearoa/tests/parental_leave/partners.yaml
+++ b/openfisca_aotearoa/tests/parental_leave/partners.yaml
@@ -9,9 +9,6 @@
     families:
       "Happy solo family":
         principal_caregiver: "biological mother"
-    titled_properties:
-      whare:
-        others: ["biological mother"]
   output:
     parental_leave__is_spouse_or_partner_of_the_biological_mother:
       2019-03:
@@ -33,9 +30,6 @@
       "Happy family":
         principal_caregiver: "other mum"
         partners: ["biological mother"]
-    titled_properties:
-      whare:
-        others: ["biological mother", "other mum"]
   output:
     parental_leave__is_spouse_or_partner_of_the_biological_mother:
       2019-03:
@@ -60,9 +54,6 @@
         principal_caregiver: "other mum"
         partners:
           - "biological mother"
-    titled_properties:
-      whare:
-        others: ["biological mother", "other mum"]
   output:
     parental_leave__is_spouse_or_partner_of_the_biological_mother:
       2019-03:
@@ -91,9 +82,6 @@
       "two":
         others:
           - "biological mother"
-    titled_properties:
-      whare:
-        others: ["biological mother", "adopting mother", "another adopting parent"]
   output:
     parental_leave__a_person_other_than_biological_mother_or_her_spouse:
       2019-03:
@@ -119,9 +107,6 @@
         principal_caregiver: "foster mother"
         partners:
           - "another foster parent"
-    titled_properties:
-      whare:
-        others: ["foster mother", "another foster parent"]
   output:
     parental_leave__a_person_other_than_biological_mother_or_her_spouse:
       2019-03:
@@ -146,9 +131,6 @@
         principal_caregiver: "biological father"
         others:
           - "biological mother"
-    titled_properties:
-      whare:
-        others: ["biological mother", "biological father"]
   output:
     parental_leave__is_spouse_or_partner_of_the_biological_mother:
       2019-03:
@@ -176,9 +158,6 @@
         partners:
           - "biological mother"
           - "another co-parenting partner"
-    titled_properties:
-      whare:
-        others: ["biological mother", "co-parent", "another co-parenting partner"]
   output:
     parental_leave__is_spouse_or_partner_of_the_biological_mother:
       2019-03:

--- a/openfisca_aotearoa/tests/parental_leave/transferring_entitlement.yaml
+++ b/openfisca_aotearoa/tests/parental_leave/transferring_entitlement.yaml
@@ -14,9 +14,6 @@
         partners:
           - "biological mother"
         principal_caregiver: "biological father"
-    titled_properties:
-      whare:
-        others: ["biological mother", "biological father"]
   output:
     parental_leave__is_spouse_or_partner_of_the_biological_mother:
       2019-03:
@@ -41,9 +38,6 @@
         partners:
           - "biological mother"
         principal_caregiver: "biological father"
-    titled_properties:
-      whare:
-        others: ["biological mother", "biological father"]
   output:
     parental_leave__has_spouse_who_transferred_her_entitlement:
       2019-03:
@@ -63,9 +57,6 @@
         partners:
           - "not the biological mother"
         principal_caregiver: "biological father"
-    titled_properties:
-      whare:
-        others: ["not the biological mother", "biological father"]
   output:
     parental_leave__has_spouse_who_transferred_her_entitlement:
       2019-03:
@@ -86,9 +77,6 @@
         others:
           - "biological mother"
         principal_caregiver: "biological father"
-    titled_properties:
-      whare:
-        others: ["biological mother", "biological father"]
   output:
     parental_leave__has_spouse_who_transferred_her_entitlement:
       2019-03:

--- a/openfisca_aotearoa/tests/relationships/relationship.yaml
+++ b/openfisca_aotearoa/tests/relationships/relationship.yaml
@@ -9,9 +9,6 @@
     families:
       Beatles:
         others: Brad
-    titled_properties:
-      whare:
-        others: Brad
   output:
     is_married_or_in_a_civil_union_or_de_facto_relationship:
       - true
@@ -27,9 +24,6 @@
         civil_union__is_in_civil_union: true
     families:
       Beatles:
-        others: Brad
-    titled_properties:
-      whare:
         others: Brad
   output:
     is_married_or_in_a_civil_union_or_de_facto_relationship:
@@ -47,9 +41,6 @@
     families:
       Beatles:
         others: Brad
-    titled_properties:
-      whare:
-        others: Brad
   output:
     is_married_or_in_a_civil_union_or_de_facto_relationship:
       - true
@@ -65,9 +56,6 @@
         is_married: false
     families:
       Beatles:
-        others: Brad
-    titled_properties:
-      whare:
         others: Brad
   output:
     is_married_or_in_a_civil_union_or_de_facto_relationship:

--- a/openfisca_aotearoa/tests/social_security/child.yaml
+++ b/openfisca_aotearoa/tests/social_security/child.yaml
@@ -21,9 +21,6 @@
       Beatles:
         children: [Paul, John, George, Ringo]
         others: [Derek, Neil]
-    titled_properties:
-      whare:
-        others: [Paul, John, George, Ringo, Derek, Neil]
   output:
     social_security__is_a_child:
       - false  # paul

--- a/openfisca_aotearoa/tests/social_security/child_disability_allowance.yaml
+++ b/openfisca_aotearoa/tests/social_security/child_disability_allowance.yaml
@@ -24,9 +24,6 @@
         principal_caregiver: Mama
         children: [ Tama_disabled_child, Tamahine_able_bodied_teenager]
         others: Papa
-    titled_properties:
-      whare:
-        others: [Mama, Papa, Tama_disabled_child, Tamahine_able_bodied_teenager]
   output:
     social_security__eligible_for_child_disability_allowance:
       - true  # mama (principal carer)
@@ -52,9 +49,6 @@
       Whanau:
         children: [Tama_disabled_child]
         principal_caregiver: Koro
-    titled_properties:
-      whare:
-        others: [Koro, Tama_disabled_child]
   output:
     social_security__eligible_for_child_disability_allowance:
       - true # Koro
@@ -78,9 +72,6 @@
       Whanau:
         principal_caregiver: Koro
         children: [Tama_disabled_child]
-    titled_properties:
-      whare:
-        others: [Koro, Tama_disabled_child]
   output:
     social_security__eligible_for_child_disability_allowance:
       - false # Koro
@@ -104,9 +95,6 @@
       Whanau:
         children: [Tama_disabled_child]
         others: [Koro]
-    titled_properties:
-      whare:
-        others: [Koro, Tama_disabled_child]
   output:
     social_security__eligible_for_child_disability_allowance:
       - false # Koro
@@ -129,9 +117,6 @@
       Whanau:
         children: [Tama_disabled_child]
         principal_caregiver: Koro
-    titled_properties:
-      whare:
-        others: [Koro, Tama_disabled_child]
   output:
     social_security__eligible_for_child_disability_allowance:
       - false # Koro
@@ -155,9 +140,6 @@
       Whanau:
         children: [Tama_disabled_child]
         principal_caregiver: Koro
-    titled_properties:
-      whare:
-        others: [Koro, Tama_disabled_child]
   output:
     social_security__eligible_for_child_disability_allowance:
       - false # Koro

--- a/openfisca_aotearoa/tests/social_security/childcare_subsidy.yaml
+++ b/openfisca_aotearoa/tests/social_security/childcare_subsidy.yaml
@@ -13,9 +13,6 @@
         early_childcare_hours_participation_per_week: 3
         is_nz_citizen: true
         is_attending_school: false
-    titled_properties:
-      "Whare":
-        others: ["Mama", "Child"]
     families:
       "Whanau":
         social_security_regulation__household_income_below_childcare_subsidy_threshold: true
@@ -46,9 +43,6 @@
         early_childcare_hours_participation_per_week: 3
         is_nz_citizen: true
         is_attending_school: false
-    titled_properties:
-      "Whare":
-        others: ["Mama", "Child"]
     families:
       "Whanau":
         social_security_regulation__household_income_below_childcare_subsidy_threshold: false
@@ -83,9 +77,6 @@
         social_security__medical_certification_months: 12
         is_nz_citizen: true
         is_attending_school: true
-    titled_properties:
-      "Whare":
-        others: ["Mama", "Child"]
     families:
       "Whanau":
         social_security_regulation__household_income_below_childcare_subsidy_threshold: true
@@ -116,9 +107,6 @@
         early_childcare_hours_participation_per_week: 3
         is_nz_citizen: true
         will_be_enrolled_in_school: true
-    titled_properties:
-      "Whare":
-        others: ["Mama", "Child"]
     families:
       "Whanau":
         principal_caregiver: "Mama"
@@ -150,9 +138,6 @@
         early_childcare_hours_participation_per_week: 3
         is_nz_citizen: true
         is_attending_school: true
-    titled_properties:
-      "Whare":
-        others: ["Mama", "Child"]
     families:
       "Whanau":
         principal_caregiver: "Mama"
@@ -177,9 +162,6 @@
         early_childcare_hours_participation_per_week: 3
         is_nz_citizen: true
         is_attending_school: false
-    titled_properties:
-      "Whare":
-        others: ["Mama", "Child"]
     families:
       "Whanau":
         principal_caregiver: "Mama"

--- a/openfisca_aotearoa/tests/social_security/community_services_card.yaml
+++ b/openfisca_aotearoa/tests/social_security/community_services_card.yaml
@@ -10,9 +10,6 @@
     families:
       Whanau_tahi:
         principal_caregiver: Mama
-    titled_properties:
-      whare:
-        others: [Mama]
   output:
     social_security__eligible_for_community_services_card:
       - false  # mama
@@ -31,9 +28,6 @@
     families:
       Whanau_tahi:
         principal_caregiver: Mama
-    titled_properties:
-      whare:
-        others: [Mama]
   output:
     social_security__eligible_for_community_services_card:
       - true  # mama
@@ -55,9 +49,6 @@
       Whanau_tahi:
         principal_caregiver: Mama
         children: [Tama]
-    titled_properties:
-      whare:
-        others: [Mama, Tama]
   output:
     social_security__eligible_for_community_services_card:
       - false  # mama
@@ -81,9 +72,6 @@
       Whanau_tahi:
         principal_caregiver: Mama
         children: [Tama]
-    titled_properties:
-      whare:
-        others: [Mama, Tama]
   output:
     social_security__eligible_for_community_services_card:
       - false  # mama
@@ -108,9 +96,6 @@
         principal_caregiver: Mama
         family_scheme__has_dependent_children: true
         children: [Tama]
-    titled_properties:
-      whare:
-        others: [Mama, Tama]
   output:
     social_security__eligible_for_community_services_card:
       - false  # mama
@@ -130,9 +115,6 @@
     families:
       Whanau_tahi:
         principal_caregiver: Mama
-    titled_properties:
-      whare:
-        others: [Mama]
   output:
     social_security__eligible_for_community_services_card:
       - true  # mama
@@ -151,9 +133,6 @@
     families:
       Whanau_tahi:
         principal_caregiver: Mama
-    titled_properties:
-      whare:
-        others: [Mama]
   output:
     social_security__eligible_for_community_services_card:
       - true  # mama
@@ -172,9 +151,6 @@
     families:
       Whanau_tahi:
         principal_caregiver: Mama
-    titled_properties:
-      whare:
-        others: [Mama]
   output:
     social_security__eligible_for_community_services_card:
       - false  # mama
@@ -192,9 +168,6 @@
     families:
       Whanau_tahi:
         principal_caregiver: Mama
-    titled_properties:
-      whare:
-        others: [Mama]
   output:
     social_security__eligible_for_community_services_card:
       - true  # mama
@@ -212,9 +185,6 @@
     families:
       Whanau_tahi:
         principal_caregiver: Mama
-    titled_properties:
-      whare:
-        others: [Mama]
   output:
     social_security__eligible_for_community_services_card:
       - true  # mama
@@ -231,9 +201,6 @@
     families:
       Whanau_tahi:
         principal_caregiver: Mama
-    titled_properties:
-      whare:
-        others: [Mama]
   output:
     social_security__eligible_for_community_services_card:
       - true  # mama
@@ -252,9 +219,6 @@
     families:
       Whanau_tahi:
         principal_caregiver: Mama
-    titled_properties:
-      whare:
-        others: [Mama]
   output:
     social_security__eligible_for_community_services_card:
       - true  # mama
@@ -273,9 +237,6 @@
     families:
       Whanau_tahi:
         principal_caregiver: Mama
-    titled_properties:
-      whare:
-        others: [Mama]
   output:
     social_security__eligible_for_community_services_card:
       - false  # mama
@@ -294,9 +255,6 @@
     families:
       Whanau_tahi:
         principal_caregiver: Mama
-    titled_properties:
-      whare:
-        others: [Mama]
   output:
     social_security__eligible_for_community_services_card:
       - true  # mama
@@ -319,9 +277,6 @@
     families:
       Whanau_tahi:
         principal_caregiver: Mama
-    titled_properties:
-      whare:
-        others: [Mama]
   output:
     social_security__eligible_for_community_services_card:
       - true  # mama
@@ -344,9 +299,6 @@
     families:
       Whanau_tahi:
         principal_caregiver: Mama
-    titled_properties:
-      whare:
-        others: [Mama]
   output:
     social_security__eligible_for_community_services_card:
       - true  # mama

--- a/openfisca_aotearoa/tests/social_security/home_help.yaml
+++ b/openfisca_aotearoa/tests/social_security/home_help.yaml
@@ -13,9 +13,6 @@
     families:
       "Whanau":
         others: ["NZ-Citizen"]
-    titled_properties:
-      whare:
-        others: ["NZ-Citizen"]
 
   output:
     home_help__eligible_for_home_help:
@@ -35,9 +32,6 @@
     families:
       "Whanau":
         principal_caregiver: "NZ-Citizen"
-    titled_properties:
-      whare:
-        others: ["NZ-Citizen"]
   output:
     home_help__eligible_for_home_help:
       - true
@@ -56,9 +50,6 @@
     families:
       "Whanau":
         principal_caregiver: "Non-Citizen"
-    titled_properties:
-      whare:
-        others: ["Non-Citizen"]
   output:
     home_help__eligible_for_home_help:
       2018-08:
@@ -77,9 +68,6 @@
     families:
       "Whanau":
         principal_caregiver: "NZ-Citizen"
-    titled_properties:
-      whare:
-        others: ["NZ-Citizen"]
   output:
     home_help__eligible_for_home_help:
       - true
@@ -96,9 +84,6 @@
         date_of_birth: 2000-12-10
     families:
       "Whanau":
-        others: ["Immediate Family"]
-    titled_properties:
-      whare:
         others: ["Immediate Family"]
 
   output:

--- a/openfisca_aotearoa/tests/social_security/jobseeker_support.yaml
+++ b/openfisca_aotearoa/tests/social_security/jobseeker_support.yaml
@@ -48,9 +48,6 @@
       Whanau:
         principal_caregiver: Mama
         others: [Tama, Papa, Alan, Dada]
-    titled_properties:
-      whare:
-        others: [Mama, Tama, Papa, Alan, Dada]
 
   output:
     social_security__eligible_for_jobseeker_support:

--- a/openfisca_aotearoa/tests/social_security/orphans.yaml
+++ b/openfisca_aotearoa/tests/social_security/orphans.yaml
@@ -19,9 +19,6 @@
         principal_caregiver: "Mama"
         children:
           - "Tama"
-    titled_properties:
-      whare:
-        others: ["Mama", "Tama"]
   output:
     social_security__eligible_for_orphans_benefit:
       - true # mama (principal carer)
@@ -46,9 +43,6 @@
         principal_caregiver: "Mama"
         children:
           - "Tama"
-    titled_properties:
-      whare:
-        others: ["Mama", "Tama"]
   output:
     social_security__eligible_for_orphans_benefit:
       - false # mama (principal carer)
@@ -73,9 +67,6 @@
         principal_caregiver: "Mama"
         children:
           - "Tama"
-    titled_properties:
-      whare:
-        others: ["Mama", "Tama"]
   output:
     social_security__eligible_for_orphans_benefit:
       - false # mama (principal carer)
@@ -99,9 +90,6 @@
         principal_caregiver: "Mama"
         children:
           - "Tama"
-    titled_properties:
-      whare:
-        others: ["Mama", "Tama"]
   output:
     social_security__eligible_for_orphans_benefit:
       - false # mama (principal carer)
@@ -126,9 +114,6 @@
         principal_caregiver: "Mama"
         children:
           - "Tama"
-    titled_properties:
-      whare:
-        others: ["Mama", "Tama"]
   output:
     social_security__eligible_for_orphans_benefit:
       - false # mama (principal carer)
@@ -153,9 +138,6 @@
         principal_caregiver: "Mama"
         children:
           - "Tama"
-    titled_properties:
-      whare:
-        others: ["Mama", "Tama"]
   output:
     social_security__eligible_for_orphans_benefit:
       - false # mama (principal carer)
@@ -180,9 +162,6 @@
         principal_caregiver: "Mama"
         children:
           - "Tama"
-    titled_properties:
-      whare:
-        others: ["Mama", "Tama"]
   output:
     social_security__eligible_for_orphans_benefit:
       2018-08:
@@ -209,9 +188,6 @@
         others: "Mama"
         children:
           - "Tama"
-    titled_properties:
-      whare:
-        others: ["Mama", "Tama"]
   output:
     social_security__eligible_for_orphans_benefit:
       2018-08:
@@ -238,9 +214,6 @@
         principal_caregiver: "Mama"
         children:
           - "Tama"
-    titled_properties:
-      whare:
-        others: ["Mama", "Tama"]
   output:
     social_security__eligible_for_orphans_benefit:
       2018-08:

--- a/openfisca_aotearoa/tests/social_security/sole_parent_support.yaml
+++ b/openfisca_aotearoa/tests/social_security/sole_parent_support.yaml
@@ -15,9 +15,6 @@
       Whanau:
         principal_caregiver: Koro
         children: Tamaiti
-    titled_properties:
-      whare:
-        others: [Koro, Tamaiti]
   output:
     social_security__eligible_for_sole_parent_support:
       - true # koro
@@ -43,9 +40,6 @@
         principal_caregiver: Papa
         partners: Mama
         children: Matilda
-    titled_properties:
-      whare:
-        others: [Papa, Mama, Matilda]
   output:
     social_security__eligible_for_sole_parent_support:
       - false # papa
@@ -74,9 +68,6 @@
         principal_caregiver: Papa
         partners: Mama
         children: Matilda
-    titled_properties:
-      whare:
-        others: [Papa, Mama, Matilda]
   output:
     social_security__eligible_for_sole_parent_support:
       - true # papa
@@ -102,9 +93,6 @@
         principal_caregiver: Koro
         children:
           - Tamaiti
-    titled_properties:
-      whare:
-        others: [Koro, Tamaiti]
   output:
     social_security__eligible_for_sole_parent_support:
       - false # koro
@@ -132,9 +120,6 @@
       Whanau:
         principal_caregiver: Koro
         children: [Tahi, Rua, Toru]
-    titled_properties:
-      whare:
-        others: [Koro, Tahi, Rua, Toru]
   output:
     social_security__eligible_for_sole_parent_support:
       - true # koro

--- a/openfisca_aotearoa/tests/social_security/super.yaml
+++ b/openfisca_aotearoa/tests/social_security/super.yaml
@@ -67,35 +67,6 @@
         veterans_support__is_entitled_to_be_paid_veterans_pension: false
         total_number_of_years_lived_in_nz_since_age_20: 11
         total_number_of_years_lived_in_nz_since_age_50: 6
-
-    families:
-      Whanau:
-        others: [
-          Not_eligible,
-          Is_citizen,
-          Is_Permanent_Resident,
-          Is_Resident,
-          Is_receiving_compensation,
-          Is_a_Veteran,
-          Is_a_NZ_Citizen,
-          Lived_in_nz_for_more_than_10_years_since_age_20,
-          Lived_in_nz_for_more_than_5_years_since_age_50
-        ]
-
-    titled_properties:
-      whare:
-        others: [
-          Not_eligible,
-          Is_citizen,
-          Is_Permanent_Resident,
-          Is_Resident,
-          Is_receiving_compensation,
-          Is_a_Veteran,
-          Is_a_NZ_Citizen,
-          Lived_in_nz_for_more_than_10_years_since_age_20,
-          Lived_in_nz_for_more_than_5_years_since_age_50
-        ]
-
   output:
     super__eligibility:
       - false # Not eligible

--- a/openfisca_aotearoa/tests/social_security/supported_living_payment.yaml
+++ b/openfisca_aotearoa/tests/social_security/supported_living_payment.yaml
@@ -11,9 +11,6 @@
     families:
       Whanau:
         others: Ruby
-    titled_properties:
-      whare:
-        others: Ruby
   output:
     social_security__eligible_for_supported_living_payment:
       - false
@@ -31,9 +28,6 @@
         social_security__meets_residential_requirements_for_certain_benefits: true
     families:
       Whanau:
-        others: Ruby
-    titled_properties:
-      whare:
         others: Ruby
   output:
     social_security__eligible_for_supported_living_payment:
@@ -53,9 +47,6 @@
         social_security__meets_residential_requirements_for_certain_benefits: true
     families:
       Whanau:
-        others: Ruby
-    titled_properties:
-      whare:
         others: Ruby
   output:
     social_security__eligible_for_supported_living_payment:
@@ -77,9 +68,6 @@
     families:
       Whanau:
         others: Ruby
-    titled_properties:
-      whare:
-        others: Ruby
   output:
     social_security__eligible_for_supported_living_payment:
       - false
@@ -98,9 +86,6 @@
     families:
       Whanau:
         principal_caregiver: Ruby
-    titled_properties:
-      whare:
-        others: Ruby
   output:
     social_security__eligible_for_supported_living_payment:
       - true
@@ -120,9 +105,6 @@
     families:
       Whanau:
         principal_caregiver: Ruby
-    titled_properties:
-      whare:
-        others: Ruby
   output:
     social_security__eligible_for_supported_living_payment:
       - false

--- a/openfisca_aotearoa/tests/social_security/unsupported_child.yaml
+++ b/openfisca_aotearoa/tests/social_security/unsupported_child.yaml
@@ -19,9 +19,6 @@
         principal_caregiver: "Mama"
         children:
           - "Tama"
-    titled_properties:
-      whare:
-        others: ["Mama", "Tama"]
   output:
     social_security__eligible_for_unsupported_childs_benefit:
       - true # mama (principal carer)
@@ -46,9 +43,6 @@
         principal_caregiver: "Mama"
         children:
           - "Tama"
-    titled_properties:
-      whare:
-        others: ["Mama", "Tama"]
   output:
     social_security__eligible_for_unsupported_childs_benefit:
       - false # mama (principal carer)
@@ -73,9 +67,6 @@
         principal_caregiver: "Mama"
         children:
           - "Tama"
-    titled_properties:
-      whare:
-        others: ["Mama", "Tama"]
   output:
     social_security__eligible_for_unsupported_childs_benefit:
       - false # mama (principal carer)
@@ -100,9 +91,6 @@
         principal_caregiver: "Mama"
         children:
           - "Tama"
-    titled_properties:
-      whare:
-        others: ["Mama", "Tama"]
   output:
     social_security__eligible_for_unsupported_childs_benefit:
       - false # mama (principal carer)
@@ -127,9 +115,6 @@
         principal_caregiver: "Mama"
         children:
           - "Tama"
-    titled_properties:
-      whare:
-        others: ["Mama", "Tama"]
   output:
     social_security__eligible_for_unsupported_childs_benefit:
       - false # mama (principal carer)
@@ -154,9 +139,6 @@
         principal_caregiver: "Mama"
         children:
           - "Tama"
-    titled_properties:
-      whare:
-        others: ["Mama", "Tama"]
   output:
     social_security__eligible_for_unsupported_childs_benefit:
       - false # mama (principal carer)
@@ -176,9 +158,6 @@
     families:
       "Whanau tahi":
         principal_caregiver: "Mama"
-    titled_properties:
-      whare:
-        others: ["Mama"]
   output:
     social_security__eligible_for_unsupported_childs_benefit:
       - false # mama (principal carer)

--- a/openfisca_aotearoa/tests/social_security/young_parent_payment.yaml
+++ b/openfisca_aotearoa/tests/social_security/young_parent_payment.yaml
@@ -34,9 +34,6 @@
         others: [Oliver]
       Two:
         principal_caregiver: Oscar
-    titled_properties:
-      whare:
-        others: [Ruby, Oliver, Oscar]
   output:
     social_security__income_under_young_parent_payment_threshold:
       - false # Ruby earns too much
@@ -90,9 +87,6 @@
         others: [Oliver]
       Two:
         principal_caregiver: Oscar
-    titled_properties:
-      whare:
-        others: [Ruby, Oliver, Oscar]
   output:
     social_security__meets_young_parent_payment_in_relationship_requirements:
       - true # previously married
@@ -132,11 +126,6 @@
         principal_caregiver: Kiwi
       Two:
         principal_caregiver: OE
-    titled_properties:
-      Tahi:
-        others: Kiwi
-      Rua:
-        others: OE
   output:
     social_security__eligible_for_young_parent_payment:
       - true # Lives in NZ

--- a/openfisca_aotearoa/tests/student_allowance/basic_grant.yaml
+++ b/openfisca_aotearoa/tests/student_allowance/basic_grant.yaml
@@ -38,14 +38,6 @@
         is_nz_citizen: true
         social_security__is_ordinarily_resident_in_new_zealand: true
         student_allowance__is_tertiary_student: false
-
-    families:
-      Whanau:
-        others: [fulltime_uni_student, Overseas_student, Refugee, Not_a_student, Parttime_student]
-    titled_properties:
-      whare:
-        others: [fulltime_uni_student, Overseas_student, Refugee, Not_a_student, Parttime_student]
-
   output:
     student_allowance__eligible_for_basic_grant:
       - true  # fulltime uni student
@@ -96,21 +88,6 @@
         student_allowance__is_secondary_student: true
         student_allowance__is_enrolled_fulltime: true
         student_allowance__meets_attendance_and_performance_requirements: true
-    families:
-      Whanau:
-        others:
-          - married_secondary_school_student_with_child
-          - not_married_secondary_school_student_with_child
-          - childless_married_secondary_school_student
-          - 18yo_secondary_student
-    titled_properties:
-      whare:
-        others:
-          - married_secondary_school_student_with_child
-          - not_married_secondary_school_student_with_child
-          - childless_married_secondary_school_student
-          - 18yo_secondary_student
-
   output:
     student_allowance__eligible_for_basic_grant:
       - true  # married secondary school student
@@ -138,13 +115,6 @@
         student_allowance__is_tertiary_student: true
         student_allowance__is_enrolled_fulltime: true
         student_allowance__meets_attendance_and_performance_requirements: true
-
-    families:
-      Whanau:
-        others: [default, not_attending, not_citizen_or_resident]
-    titled_properties:
-      whare:
-        others: [default, not_attending, not_citizen_or_resident]
 
   output:
     student_allowance__eligible_for_basic_grant:
@@ -184,14 +154,6 @@
         student_allowance__is_tertiary_student: true
         student_allowance__is_enrolled_fulltime: true
         student_allowance__meets_attendance_and_performance_requirements: true
-
-    families:
-      Whanau:
-        others: [fulltime_uni_studdent, Parttime_student, Overseas_student, Refugee]
-    titled_properties:
-      whare:
-        others: [fulltime_uni_studdent, Parttime_student, Overseas_student, Refugee]
-
   output:
     student_allowance__eligible_for_basic_grant:
       - false  # fulltime uni student

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='OpenFisca-Aotearoa',
-    version='11.1.1',
+    version='11.1.2',
     author='New Zealand Government, Service Innovation Lab',
     author_email='brenda.wallace@dia.govt.nz,hamish.fraser@dia.govt.nz',
     description=u'OpenFisca tax and benefit system for Aotearoa',


### PR DESCRIPTION
These groups were needed in older versions of openfisca, but not anymore
* Technical improvement.
