### PR TITLE
.circleci/*.sh: Code standards fixes for #172

### DIFF
--- a/.circleci/check-version-bump.sh
+++ b/.circleci/check-version-bump.sh
@@ -2,16 +2,16 @@
 
 VERSION_CHANGE_TRIGGERS="setup.py MANIFEST.in openfisca_aotearoa"
 
-if git diff-index --quiet origin/master -- $VERSION_CHANGE_TRIGGERS ":(exclude)*.md"
+if git diff-index --quiet origin/master -- "$VERSION_CHANGE_TRIGGERS" ":(exclude)*.md"
 then exit 0  # there are no changes at all, the version is correct
 fi
 
-current_version=`python setup.py --version`
+current_version=$(python setup.py --version)
 
-if git rev-parse --verify --quiet $current_version
+if git rev-parse --verify --quiet "$current_version"
 then
     echo "Version $current_version already exists:"
-    git --no-pager log -1 $current_version
+    git --no-pager log -1 "$current_version"
     echo
     echo "Update the version number in setup.py before merging this branch into master."
     echo "Look at the CONTRIBUTING.md file to learn how the version number should be updated."

--- a/.circleci/deploy-if-version-bump.sh
+++ b/.circleci/deploy-if-version-bump.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 
 set -e
-if ! git rev-parse `python setup.py --version` 2>/dev/null ; then
-    git tag `python setup.py --version`
+if ! git rev-parse "$(python setup.py --version)" 2>/dev/null ; then
+    git tag "$(python setup.py --version)"
     git push --tags  # update the repository version
     python setup.py bdist_wheel  # build this package in the dist directory
-    twine upload dist/* --username $PYPI_USERNAME --password $PYPI_PASSWORD  # publish
+    twine upload dist/* --username "$PYPI_USERNAME" --password "$PYPI_PASSWORD"  # publish
 else
     echo "Only non-functional elements were modified in this change, there is no need to deploy."
     echo

--- a/.circleci/git_tag.sh
+++ b/.circleci/git_tag.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 
 set -ev
-VERSION=`python setup.py --version`
+VERSION="$(python setup.py --version)"
 
-if ! git rev-parse $VERSION 2>/dev/null ; then
-  git tag $VERSION
-  git push origin $VERSION
+if ! git rev-parse "$VERSION" 2>/dev/null ; then
+  git tag "$VERSION"
+  git push origin "$VERSION"
 fi


### PR DESCRIPTION
Thanks for contributing to OpenFisca ! Please remove this line, as well as, for each line below, the cases which are not relevant to your contribution :)

* Minor change.
* Impacted areas: `.circleci/*.sh`
* Details:
  - Addresses #172 
  - Code standards fixes for the `shellcheck` tool used in CodeFactor. Covers:
    - SC2006: Use $(..) instead of legacy \`..\`.
    - SC2046: Quote this to prevent word splitting.
    - SC2086: Double quote to prevent globbing and word splitting.
  - CodeFactor usually ignores the latter two as not strictly necessary, but I figured I may as well while I was there. I can revert as necessary.


- - - -

These changes _(remove lines which are not relevant to your contribution)_:

- Change non-functional parts of this repository (for instance editing the README)
