### PR TITLE
Added tests for rates rebates in 2020

### DIFF
--- a/openfisca_aotearoa/tests/rates_rebates/rates_rebates_2020.yaml
+++ b/openfisca_aotearoa/tests/rates_rebates/rates_rebates_2020.yaml
@@ -8,7 +8,6 @@
     rates_rebates__rates_total: 1200
   output:
     rates_rebates__rebate: 640.00
-    # rates_rebates__maximum_income_for_full_rebate: 24620
 
 - name: Rates Rebate - 2019 to 2020 form example 1x2. income $25,000 rates $1,400
   absolute_error_margin: 0.01

--- a/openfisca_aotearoa/tests/rates_rebates/rates_rebates_2020.yaml
+++ b/openfisca_aotearoa/tests/rates_rebates/rates_rebates_2020.yaml
@@ -1,0 +1,51 @@
+# Copied from the 2019/2020 Form
+- name: Rates Rebate - 2019 to 2020 form - income $25,000 rates $1,200
+  absolute_error_margin: 0.01
+  period: 2020
+  input:
+    rates_rebates__combined_income: 25000
+    rates_rebates__dependants: 0
+    rates_rebates__rates_total: 1200
+  output:
+    rates_rebates__rebate: 640.00
+    # rates_rebates__maximum_income_for_full_rebate: 24620
+
+- name: Rates Rebate - 2019 to 2020 form example 1x2. income $25,000 rates $1,400
+  absolute_error_margin: 0.01
+  period: 2020
+  input:
+    rates_rebates__combined_income: 25000
+    rates_rebates__dependants: 0
+    rates_rebates__rates_total: 1400
+  output:
+    rates_rebates__rebate: 640.00
+
+- name: Rates Rebate - 2019 to 2020 form example income $28,000 rates $1,200
+  absolute_error_margin: 0.01
+  period: 2020
+  input:
+    rates_rebates__combined_income: 28000
+    rates_rebates__dependants: 0
+    rates_rebates__rates_total: 1200
+  output:
+    rates_rebates__rebate: 401.33
+
+- name: Rates Rebate - 2019 to 2020 form example - income $40,000 rates $3,000
+  absolute_error_margin: 0.01
+  period: 2020
+  input:
+    rates_rebates__combined_income: 40000
+    rates_rebates__dependants: 0
+    rates_rebates__rates_total: 3000
+  output:
+    rates_rebates__rebate: 101.33
+
+- name: Rates Rebate - 2019 to 2020 form example - income $44,000 rates $3,500
+  absolute_error_margin: 0.01
+  period: 2020
+  input:
+    rates_rebates__combined_income: 44000
+    rates_rebates__dependants: 0
+    rates_rebates__rates_total: 3500
+  output:
+    rates_rebates__rebate: 0.00


### PR DESCRIPTION
Added tests for rates rebates into the end of June 2020, as per the DIA pdf

The following is from the 2020 form, for zero dependents
![image](https://user-images.githubusercontent.com/12266/60403675-717f3b80-9bf4-11e9-89f6-e15903dc2874.png)
