### PR TITLE
Pin versions of psutil, gunicorn and werkzeug

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,8 @@ PyYAML >= 3.10
 sortedcontainers==1.5.9
 flask == 1.0.2
 flask-cors ==3.0.7
-gunicorn >= 19.7.1
+gunicorn <= 19.9.0
+werkzeug < 1.0.0
 
 
 # Old requirements, to install stable core instead of git

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ dpath == 1.4.0
 enum34 >= 1.1.6
 future < 1.0.0
 numpy >= 1.11, < 1.16
-psutil==5.6.6
+psutil==5.4.6
 PyYAML >= 3.10
 sortedcontainers==1.5.9
 flask == 1.0.2


### PR DESCRIPTION
werkzeug and gunicorn have removed APIs relied upon by openfisca 30.
psutil 5.4.6 is required by openfisca 30.0.1