### PR TITLE
Run tests with docker

### DIFF
--- a/SETUP-docker.md
+++ b/SETUP-docker.md
@@ -6,6 +6,12 @@
 - Build the docker image: `docker build . -t openfisca-aotearoa`
 - Run the image: `docker run -it -p 5000:5000 openfisca-aotearoa`
 
+## Run tests using Docker
+
+- [Install Docker](https://www.docker.com/get-started).
+- Run the tests using docker compose: `docker compose run openfisca_test`
+
+
 ## Serve OpenFisca Aotearoa with the OpenFisca Web API
 
 If you are considering building a web application, you can use the packaged OpenFisca Web API.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+services:
+  openfisca_test:
+    build:
+      context: '.'
+      dockerfile: './openfisca_aotearoa/tests/Dockerfile'
+    working_dir: /app
+    volumes:
+      - ./:/app

--- a/openfisca_aotearoa/tests/Dockerfile
+++ b/openfisca_aotearoa/tests/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.7.2-stretch
+WORKDIR /app
+
+COPY setup.py /app/setup.py
+COPY setup.cfg /app/setup.cfg
+COPY requirements.txt /app/requirements.txt
+
+RUN pip install --upgrade pip && \
+  pip install numpy'<1.16,>=1.11' && \
+  pip install -r /app/requirements.txt && \
+  pip install -e '.[test]'
+
+CMD [ "openfisca-run-test", "--country-package", "openfisca_aotearoa", "openfisca_aotearoa/tests" ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ psutil==5.4.6
 PyYAML >= 3.10
 sortedcontainers==1.5.9
 flask == 1.0.2
-flask-cors ==3.0.7
+flask-cors ==3.0.2
 gunicorn <= 19.9.0
 werkzeug < 1.0.0
 


### PR DESCRIPTION
* Technical improvement.
* Details:
  - Set up a Dockerfile and docker-compose file to allow running tests with docker, because setting up the libraries with the currently specified versions in pyenv was causing problems on an M1 mac.
  - there was one patch version dependency that pip insisted i change even when installing everything within docker (flask-cors)
  - i chose not to modify the existing Dockerfile, or add it to the docker-compose to avoid affecting existing workflows

- - - -

These changes:

- Change non-functional parts of this repository
- Add an alternative way to run tests
