### PR TITLE
feat: 2025+ schedule income tax, ACC earners levy, KiwiSaver rates (#199)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+### Unreleased — income tax / ACC earners levy / KiwiSaver coverage (#199)
+
+* Tax and benefit system evolution.
+* Impacted periods: 2021-04 onwards (income tax); 2023-04 onwards (ACC earners levy); 2013-04 / 2026-04 / 2028-04 (KiwiSaver rates).
+* Impacted areas:
+  - `parameters/taxes/income_tax/individual_income_tax_rate.yaml`
+  - `parameters/acc/earners_levy/`
+  - `parameters/kiwisaver/`
+  - `variables/acts/income_tax/individual.py`
+  - `variables/acts/acc/earners_levy.py`
+  - `variables/acts/kiwisaver/contributions.py`
+* Added variables:
+  - `income_tax__schedule_1_tax_before_credits`
+  - `income_tax__income_tax_before_credits` (alias)
+  - `acc__earnings_for_earners_levy`
+  - `acc__earners_levy_including_gst`
+  - `acc__earners_levy` (alias)
+  - `kiwisaver__gross_salary_or_wages`
+  - `kiwisaver__employee_minimum_contribution`
+  - `kiwisaver__employer_minimum_contribution`
+* Notes:
+  - YEAR formulas look up 1 April parameters for the calendar year of the period (NZ tax/levy year convention).
+  - Rates cited from IRD public pages; Schedule 1 progressive tax is before credits and excludes ACC levy.
+
 ### 22.0.0 - [69](https://github.com/digitalaotearoa/openfisca-aotearoa/pull/64)
 
 * Tax and benefit system evolution.

--- a/openfisca_aotearoa/parameters/acc/earners_levy/maximum_earnings.yaml
+++ b/openfisca_aotearoa/parameters/acc/earners_levy/maximum_earnings.yaml
@@ -1,0 +1,20 @@
+description: Maximum earnings subject to ACC earners' levy in a levy year
+# Source verified 2026-07-09:
+# https://www.ird.govt.nz/income-tax/income-tax-for-individuals/acc-clients-and-carers/acc-earners-levy-rates
+metadata:
+  unit: currency-NZD
+  reference:
+    2023-04-01:
+      title: ACC earners' levy rates — maximum earnings (IRD)
+      href: https://www.ird.govt.nz/income-tax/income-tax-for-individuals/acc-clients-and-carers/acc-earners-levy-rates
+values:
+  2023-04-01:
+    value: 139384
+  2024-04-01:
+    value: 142283
+  2025-04-01:
+    value: 152790
+  2026-04-01:
+    value: 156641
+  2027-04-01:
+    value: 160244

--- a/openfisca_aotearoa/parameters/acc/earners_levy/maximum_levy_payable.yaml
+++ b/openfisca_aotearoa/parameters/acc/earners_levy/maximum_levy_payable.yaml
@@ -1,0 +1,21 @@
+description: Maximum ACC earners' levy payable (including GST) in a levy year
+# Equals maximum_earnings * rate_including_gst (published by IRD for cross-check).
+# Source verified 2026-07-09:
+# https://www.ird.govt.nz/income-tax/income-tax-for-individuals/acc-clients-and-carers/acc-earners-levy-rates
+metadata:
+  unit: currency-NZD
+  reference:
+    2023-04-01:
+      title: ACC earners' levy rates — maximum levy payable (IRD)
+      href: https://www.ird.govt.nz/income-tax/income-tax-for-individuals/acc-clients-and-carers/acc-earners-levy-rates
+values:
+  2023-04-01:
+    value: 2132.57
+  2024-04-01:
+    value: 2276.52
+  2025-04-01:
+    value: 2551.59
+  2026-04-01:
+    value: 2741.22
+  2027-04-01:
+    value: 2932.47

--- a/openfisca_aotearoa/parameters/acc/earners_levy/rate_including_gst.yaml
+++ b/openfisca_aotearoa/parameters/acc/earners_levy/rate_including_gst.yaml
@@ -1,0 +1,21 @@
+description: ACC earners' levy rate including GST (flat rate per dollar of liable earnings)
+# IRD publishes the earners' levy as $X per $100 of earnings, including GST.
+# Source verified 2026-07-09:
+# https://www.ird.govt.nz/income-tax/income-tax-for-individuals/acc-clients-and-carers/acc-earners-levy-rates
+metadata:
+  unit: /1
+  reference:
+    2023-04-01:
+      title: ACC earners' levy rates (IRD)
+      href: https://www.ird.govt.nz/income-tax/income-tax-for-individuals/acc-clients-and-carers/acc-earners-levy-rates
+values:
+  2023-04-01:
+    value: 0.0153
+  2024-04-01:
+    value: 0.0160
+  2025-04-01:
+    value: 0.0167
+  2026-04-01:
+    value: 0.0175
+  2027-04-01:
+    value: 0.0183

--- a/openfisca_aotearoa/parameters/kiwisaver/employee_minimum_contribution_rate.yaml
+++ b/openfisca_aotearoa/parameters/kiwisaver/employee_minimum_contribution_rate.yaml
@@ -1,0 +1,25 @@
+description: Minimum / default employee KiwiSaver contribution rate of gross salary or wages
+# Sources verified 2026-07-09:
+# - https://www.ird.govt.nz/kiwisaver-changes
+# - https://www.ird.govt.nz/kiwisaver/kiwisaver-individuals/kiwisaver-benefits
+# - https://www.ird.govt.nz/kiwisaver/kiwisaver-employers/contributions-and-deductions/employer-contributions-to-kiwisaver-and-complying-funds
+# Legal minimum/default was 3% until 31 March 2026; rises to 3.5% from 1 April 2026 and 4% from 1 April 2028.
+metadata:
+  unit: /1
+  reference:
+    2013-04-01:
+      title: KiwiSaver employee contribution rates (historical minimum 3%)
+      href: https://www.ird.govt.nz/kiwisaver/kiwisaver-individuals/making-contributions/how-much-you-need-to-contribute
+    2026-04-01:
+      title: KiwiSaver changes — minimum contribution rate 3.5% from 1 April 2026
+      href: https://www.ird.govt.nz/kiwisaver-changes
+    2028-04-01:
+      title: KiwiSaver changes — minimum contribution rate 4% from 1 April 2028
+      href: https://www.ird.govt.nz/kiwisaver-changes
+values:
+  2013-04-01:
+    value: 0.03
+  2026-04-01:
+    value: 0.035
+  2028-04-01:
+    value: 0.04

--- a/openfisca_aotearoa/parameters/kiwisaver/employer_minimum_contribution_rate.yaml
+++ b/openfisca_aotearoa/parameters/kiwisaver/employer_minimum_contribution_rate.yaml
@@ -1,0 +1,24 @@
+description: Minimum compulsory employer KiwiSaver contribution rate of employee's gross salary or wages
+# Sources verified 2026-07-09:
+# - https://www.ird.govt.nz/kiwisaver-changes
+# - https://www.ird.govt.nz/kiwisaver/kiwisaver-employers/contributions-and-deductions/employer-contributions-to-kiwisaver-and-complying-funds
+# Compulsory employer contribution was 3% until 31 March 2026; rises to 3.5% from 1 April 2026 and 4% from 1 April 2028.
+metadata:
+  unit: /1
+  reference:
+    2013-04-01:
+      title: Compulsory employer contributions (historical minimum 3%)
+      href: https://www.ird.govt.nz/kiwisaver/kiwisaver-employers/contributions-and-deductions/employer-contributions-to-kiwisaver-and-complying-funds
+    2026-04-01:
+      title: KiwiSaver changes — employer minimum 3.5% from 1 April 2026
+      href: https://www.ird.govt.nz/kiwisaver-changes
+    2028-04-01:
+      title: KiwiSaver changes — employer minimum 4% from 1 April 2028
+      href: https://www.ird.govt.nz/kiwisaver-changes
+values:
+  2013-04-01:
+    value: 0.03
+  2026-04-01:
+    value: 0.035
+  2028-04-01:
+    value: 0.04

--- a/openfisca_aotearoa/parameters/taxes/income_tax/individual_income_tax_rate.yaml
+++ b/openfisca_aotearoa/parameters/taxes/income_tax/individual_income_tax_rate.yaml
@@ -1,6 +1,30 @@
-description: Individual income tax rate
-reference: https://www.parliament.nz/en/pb/research-papers/document/00PLEcoC5191/income-tax-rates
-# Actual link to act: http://www.legislation.govt.nz/act/public/2007/0097/latest/versions.aspx
+description: Individual income tax rate (Income Tax Act 2007 Schedule 1 progressive rates)
+# Marginal scale: each bracket's rate applies to income from its threshold up to the next threshold.
+# Thresholds follow IRD published upper-bound bands (rate applies to dollars above the prior band ceiling).
+#
+# Primary sources (verified 2026-07-09):
+# - IRD tax rates for individuals:
+#   https://www.ird.govt.nz/income-tax/income-tax-for-individuals/tax-codes-and-tax-rates-for-individuals/tax-rates-for-individuals
+# - Income Tax Act 2007 Schedule 1 (basic tax rates for individuals):
+#   https://www.legislation.govt.nz/act/public/2007/0097/latest/DLM1523138.html
+# - 39% top rate from 1 April 2021:
+#   https://www.taxtechnical.ird.govt.nz/new-legislation/act-articles/2021/public-2020-no-65
+metadata:
+  type: marginal_rate
+  unit: /1
+  reference:
+    2010-10-01:
+      title: Income tax rates (historical parliament research paper)
+      href: https://www.parliament.nz/en/pb/research-papers/document/00PLEcoC5191/income-tax-rates
+    2021-04-01:
+      title: Taxation (Income Tax Rate and Other Amendments) Act 2020 — 39% rate
+      href: https://www.taxtechnical.ird.govt.nz/new-legislation/act-articles/2021/public-2020-no-65
+    2024-04-01:
+      title: IRD tax rates for individuals (1 April 2024 to 31 March 2025 transitional brackets)
+      href: https://www.ird.govt.nz/income-tax/income-tax-for-individuals/tax-codes-and-tax-rates-for-individuals/tax-rates-for-individuals
+    2025-04-01:
+      title: IRD tax rates for individuals (from 1 April 2025)
+      href: https://www.ird.govt.nz/income-tax/income-tax-for-individuals/tax-codes-and-tax-rates-for-individuals/tax-rates-for-individuals
 brackets:
 - rate:
     2000-04-01:
@@ -11,6 +35,12 @@ brackets:
       value: 0.125
     2010-10-01:
       value: 0.105
+    2021-04-01:
+      value: 0.105
+    2024-04-01:
+      value: 0.105
+    2025-04-01:
+      value: 0.105
   threshold:
     2000-04-01:
       value: 0.0
@@ -19,6 +49,12 @@ brackets:
     2009-04-01:
       value: 0.0
     2010-10-01:
+      value: 0.0
+    2021-04-01:
+      value: 0.0
+    2024-04-01:
+      value: 0.0
+    2025-04-01:
       value: 0.0
 - rate:
     2000-04-01:
@@ -29,6 +65,13 @@ brackets:
       value: 0.21
     2010-10-01:
       value: 0.175
+    2021-04-01:
+      value: 0.175
+    # 2024-25 transitional intermediate band (IRD)
+    2024-04-01:
+      value: 0.1282
+    2025-04-01:
+      value: 0.175
   threshold:
     2000-04-01:
       value: 9501.0
@@ -38,6 +81,12 @@ brackets:
       value: 14001.0
     2010-10-01:
       value: 14001.0
+    2021-04-01:
+      value: 14000.0
+    2024-04-01:
+      value: 14000.0
+    2025-04-01:
+      value: 15600.0
 - rate:
     2000-04-01:
       value: 0.33
@@ -46,6 +95,12 @@ brackets:
     2009-04-01:
       value: 0.33
     2010-10-01:
+      value: 0.3
+    2021-04-01:
+      value: 0.3
+    2024-04-01:
+      value: 0.175
+    2025-04-01:
       value: 0.3
   threshold:
     2000-04-01:
@@ -56,6 +111,12 @@ brackets:
       value: 48001.0
     2010-10-01:
       value: 48001.0
+    2021-04-01:
+      value: 48000.0
+    2024-04-01:
+      value: 15600.0
+    2025-04-01:
+      value: 53500.0
 - rate:
     2000-04-01:
       value: 0.39
@@ -64,6 +125,12 @@ brackets:
     2009-04-01:
       value: 0.38
     2010-10-01:
+      value: 0.33
+    2021-04-01:
+      value: 0.33
+    2024-04-01:
+      value: 0.2164
+    2025-04-01:
       value: 0.33
   threshold:
     2000-04-01:
@@ -74,3 +141,56 @@ brackets:
       value: 70001.0
     2010-10-01:
       value: 70001.0
+    2021-04-01:
+      value: 70000.0
+    2024-04-01:
+      value: 48000.0
+    2025-04-01:
+      value: 78100.0
+# Fifth bracket: 39% top personal rate from 1 April 2021.
+# In 2024-25 this index is an intermediate transitional band; top rate moves to later brackets.
+- rate:
+    2021-04-01:
+      value: 0.39
+    2024-04-01:
+      value: 0.3
+    2025-04-01:
+      value: 0.39
+  threshold:
+    2021-04-01:
+      value: 180000.0
+    2024-04-01:
+      value: 53500.0
+    2025-04-01:
+      value: 180000.0
+# 2024-25 transitional-only brackets (null from 2025-04-01 when scale returns to five bands)
+- rate:
+    2024-04-01:
+      value: 0.3099
+    2025-04-01:
+      value: null
+  threshold:
+    2024-04-01:
+      value: 70000.0
+    2025-04-01:
+      value: null
+- rate:
+    2024-04-01:
+      value: 0.33
+    2025-04-01:
+      value: null
+  threshold:
+    2024-04-01:
+      value: 78100.0
+    2025-04-01:
+      value: null
+- rate:
+    2024-04-01:
+      value: 0.39
+    2025-04-01:
+      value: null
+  threshold:
+    2024-04-01:
+      value: 180000.0
+    2025-04-01:
+      value: null

--- a/openfisca_aotearoa/tests/acc/earners_levy.yaml
+++ b/openfisca_aotearoa/tests/acc/earners_levy.yaml
@@ -1,0 +1,48 @@
+# ACC earners' levy (standard employee calculation, rates include GST).
+# IRD 1 April 2026 – 31 March 2027: 1.75% up to $156,641; max levy $2,741.22
+# https://www.ird.govt.nz/income-tax/income-tax-for-individuals/acc-clients-and-carers/acc-earners-levy-rates
+#
+# Calendar year period 2026 looks up parameters at 2026-04-01.
+
+- name: earners_levy_standard_2026_earnings_below_cap
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    acc__earnings_for_earners_levy: 100000
+  output:
+    acc__earners_levy_including_gst: 1750
+    acc__earners_levy: 1750
+
+- name: earners_levy_standard_2026_earnings_at_cap
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    acc__earnings_for_earners_levy: 156641
+  output:
+    acc__earners_levy_including_gst: 2741.2175
+
+- name: earners_levy_standard_2026_earnings_above_cap
+  period: 2026
+  absolute_error_margin: 0.02
+  input:
+    acc__earnings_for_earners_levy: 200000
+  output:
+    # min(200000, 156641) * 0.0175 = 2741.2175 (IRD published max 2741.22)
+    acc__earners_levy_including_gst: 2741.2175
+
+- name: earners_levy_standard_negative_earnings
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    acc__earnings_for_earners_levy: -100
+  output:
+    acc__earners_levy_including_gst: 0
+
+- name: earners_levy_standard_2025_rate
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    acc__earnings_for_earners_levy: 100000
+  output:
+    # 2025-04-01 rate 1.67%
+    acc__earners_levy_including_gst: 1670

--- a/openfisca_aotearoa/tests/income_tax/schedule_1_tax_before_credits.yaml
+++ b/openfisca_aotearoa/tests/income_tax/schedule_1_tax_before_credits.yaml
@@ -1,0 +1,60 @@
+# Schedule 1 progressive income tax before credits.
+# Expected values match IRD progressive application of rates from 1 April 2025
+# (used for calendar year 2026 simulations via April parameter lookup):
+# https://www.ird.govt.nz/income-tax/income-tax-for-individuals/tax-codes-and-tax-rates-for-individuals/tax-rates-for-individuals
+#
+# Tax on 15600 @ 10.5% = 1638
+# Tax on 53500 = 15600*0.105 + (53500-15600)*0.175 = 8270.5
+# Tax on 180000 = 8270.5 + (78100-53500)*0.30 + (180000-78100)*0.33 = 49277.5
+# Tax on 200000 = 49277.5 + 20000*0.39 = 57077.5
+
+- name: schedule_1_first_bracket_upper_bound_2026
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    income_tax__taxable_income: 15600
+  output:
+    income_tax__schedule_1_tax_before_credits: 1638
+    income_tax__income_tax_before_credits: 1638
+
+- name: schedule_1_second_bracket_upper_bound_2026
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    income_tax__taxable_income: 53500
+  output:
+    income_tax__schedule_1_tax_before_credits: 8270.5
+
+- name: schedule_1_fourth_bracket_upper_bound_2026
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    income_tax__taxable_income: 180000
+  output:
+    income_tax__schedule_1_tax_before_credits: 49277.5
+
+- name: schedule_1_top_bracket_income_2026
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    income_tax__taxable_income: 200000
+  output:
+    income_tax__schedule_1_tax_before_credits: 57077.5
+
+- name: schedule_1_nonpositive_taxable_income_2026
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    income_tax__taxable_income: 0
+  output:
+    income_tax__schedule_1_tax_before_credits: 0
+
+- name: schedule_1_via_net_income_path_2026
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    income_tax__annual_gross_income: 60000
+    income_tax__annual_total_deduction: 6500
+  output:
+    income_tax__taxable_income: 53500
+    income_tax__schedule_1_tax_before_credits: 8270.5

--- a/openfisca_aotearoa/tests/kiwisaver/minimum_contributions.yaml
+++ b/openfisca_aotearoa/tests/kiwisaver/minimum_contributions.yaml
@@ -28,3 +28,12 @@
   output:
     kiwisaver__employee_minimum_contribution: 4000
     kiwisaver__employer_minimum_contribution: 4000
+
+- name: kiwisaver_negative_salary_does_not_create_contributions
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    kiwisaver__gross_salary_or_wages: -100
+  output:
+    kiwisaver__employee_minimum_contribution: 0
+    kiwisaver__employer_minimum_contribution: 0

--- a/openfisca_aotearoa/tests/kiwisaver/minimum_contributions.yaml
+++ b/openfisca_aotearoa/tests/kiwisaver/minimum_contributions.yaml
@@ -1,0 +1,30 @@
+# KiwiSaver minimum employee/employer contribution rates.
+# https://www.ird.govt.nz/kiwisaver-changes
+# 3% until 31 March 2026; 3.5% from 1 April 2026; 4% from 1 April 2028.
+
+- name: kiwisaver_minimum_contributions_2025_at_3_percent
+  period: 2025
+  absolute_error_margin: 0.01
+  input:
+    kiwisaver__gross_salary_or_wages: 100000
+  output:
+    kiwisaver__employee_minimum_contribution: 3000
+    kiwisaver__employer_minimum_contribution: 3000
+
+- name: kiwisaver_minimum_contributions_2026_at_3_5_percent
+  period: 2026
+  absolute_error_margin: 0.01
+  input:
+    kiwisaver__gross_salary_or_wages: 100000
+  output:
+    kiwisaver__employee_minimum_contribution: 3500
+    kiwisaver__employer_minimum_contribution: 3500
+
+- name: kiwisaver_minimum_contributions_2028_at_4_percent
+  period: 2028
+  absolute_error_margin: 0.01
+  input:
+    kiwisaver__gross_salary_or_wages: 100000
+  output:
+    kiwisaver__employee_minimum_contribution: 4000
+    kiwisaver__employer_minimum_contribution: 4000

--- a/openfisca_aotearoa/variables/acts/acc/earners_levy.py
+++ b/openfisca_aotearoa/variables/acts/acc/earners_levy.py
@@ -1,0 +1,62 @@
+"""ACC earners' levy — standard employee calculation.
+
+Rates and maximum earnings are taken from IRD's published earners' levy tables
+(amounts include GST). This module models the standard flat-rate employee levy
+with the annual earnings cap. Self-employed minimum-earnings rules and work
+account levies are out of scope here.
+"""
+
+import numpy
+
+from openfisca_core.periods import YEAR
+from openfisca_core.variables import Variable
+
+from openfisca_aotearoa.entities import Person
+from openfisca_aotearoa.variables.acts.income_tax.individual import (
+    _nz_tax_year_april_instant,
+    )
+
+
+class acc__earnings_for_earners_levy(Variable):
+    value_type = float
+    entity = Person
+    definition_period = YEAR
+    unit = "NZD"
+    label = "Annual earnings liable for ACC earners' levy (input)"
+    reference = "https://www.ird.govt.nz/income-tax/income-tax-for-individuals/acc-clients-and-carers/acc-earners-levy-rates"
+
+
+class acc__earners_levy_including_gst(Variable):
+    value_type = float
+    entity = Person
+    definition_period = YEAR
+    unit = "NZD"
+    label = (
+        "Standard ACC earners' levy including GST "
+        "(rate × min(earnings, maximum earnings); zero if earnings ≤ 0)"
+        )
+    reference = [
+        "https://www.ird.govt.nz/income-tax/income-tax-for-individuals/acc-clients-and-carers/acc-earners-levy-rates",
+        ]
+
+    def formula(persons, period, parameters):
+        earnings = persons("acc__earnings_for_earners_levy", period)
+        p = parameters(_nz_tax_year_april_instant(period)).acc.earners_levy
+        rate = p.rate_including_gst
+        maximum_earnings = p.maximum_earnings
+        liable = numpy.minimum(numpy.maximum(earnings, 0.0), maximum_earnings)
+        return liable * rate
+
+
+class acc__earners_levy(Variable):
+    """Alias for the standard including-GST levy amount."""
+
+    value_type = float
+    entity = Person
+    definition_period = YEAR
+    unit = "NZD"
+    label = "Standard ACC earners' levy including GST (alias of acc__earners_levy_including_gst)"
+    reference = "https://www.ird.govt.nz/income-tax/income-tax-for-individuals/acc-clients-and-carers/acc-earners-levy-rates"
+
+    def formula(persons, period, parameters):
+        return persons("acc__earners_levy_including_gst", period)

--- a/openfisca_aotearoa/variables/acts/income_tax/individual.py
+++ b/openfisca_aotearoa/variables/acts/income_tax/individual.py
@@ -86,3 +86,53 @@ class income_tax__taxable_income(Variable):
         return (
             taxable_income * (taxable_income > 0)
             )
+
+
+def _nz_tax_year_april_instant(period):
+    """NZ tax / levy years generally commence 1 April.
+
+    OpenFisca YEAR periods start on 1 January. For annual assessments that use
+    rates in force for the April–March tax year, look up parameters as at
+    1 April of the same calendar year as ``period.start``.
+
+    Example: period ``2026`` (calendar) → parameter instant ``2026-04-01``.
+    """
+    return period.start.offset(3, "month")
+
+
+class income_tax__schedule_1_tax_before_credits(Variable):
+    value_type = float
+    entity = Person
+    definition_period = YEAR
+    unit = "NZD"
+    label = (
+        "Schedule 1 individual income tax on taxable income before credits "
+        "(progressive marginal scale; excludes ACC earners' levy and tax credits)"
+        )
+    reference = [
+        "https://www.legislation.govt.nz/act/public/2007/0097/latest/DLM1523138.html",
+        "https://www.ird.govt.nz/income-tax/income-tax-for-individuals/tax-codes-and-tax-rates-for-individuals/tax-rates-for-individuals",
+        ]
+
+    def formula(person, period, parameters):
+        taxable_income = person("income_tax__taxable_income", period)
+        # Non-positive taxable income yields zero tax (scale also returns 0 for negatives).
+        scale = parameters(_nz_tax_year_april_instant(period)).taxes.income_tax.individual_income_tax_rate
+        return scale.calc(taxable_income)
+
+
+class income_tax__income_tax_before_credits(Variable):
+    """Alias aligned with comparative / RuleSpec naming."""
+
+    value_type = float
+    entity = Person
+    definition_period = YEAR
+    unit = "NZD"
+    label = "Individual income tax before credits (alias of income_tax__schedule_1_tax_before_credits)"
+    reference = [
+        "https://www.legislation.govt.nz/act/public/2007/0097/latest/DLM1523138.html",
+        "https://www.ird.govt.nz/income-tax/income-tax-for-individuals/tax-codes-and-tax-rates-for-individuals/tax-rates-for-individuals",
+        ]
+
+    def formula(person, period, parameters):
+        return person("income_tax__schedule_1_tax_before_credits", period)

--- a/openfisca_aotearoa/variables/acts/kiwisaver/contributions.py
+++ b/openfisca_aotearoa/variables/acts/kiwisaver/contributions.py
@@ -6,6 +6,8 @@ holidays, ESCT, Crown contributions, and opted-up employee rates are out of
 scope.
 """
 
+import numpy
+
 from openfisca_core.periods import YEAR
 from openfisca_core.variables import Variable
 
@@ -13,6 +15,11 @@ from openfisca_aotearoa.entities import Person
 from openfisca_aotearoa.variables.acts.income_tax.individual import (
     _nz_tax_year_april_instant,
     )
+
+
+def max_(left, right):
+    """Element-wise maximum compatible with OpenFisca vector formulas."""
+    return numpy.maximum(left, right)
 
 
 class kiwisaver__gross_salary_or_wages(Variable):
@@ -40,7 +47,8 @@ class kiwisaver__employee_minimum_contribution(Variable):
         rate = parameters(
             _nz_tax_year_april_instant(period)
             ).kiwisaver.employee_minimum_contribution_rate
-        return earnings * rate
+        # Contributions are never negative; clamp base like RuleSpec companion tests.
+        return max_(earnings, 0) * rate
 
 
 class kiwisaver__employer_minimum_contribution(Variable):
@@ -59,4 +67,4 @@ class kiwisaver__employer_minimum_contribution(Variable):
         rate = parameters(
             _nz_tax_year_april_instant(period)
             ).kiwisaver.employer_minimum_contribution_rate
-        return earnings * rate
+        return max_(earnings, 0) * rate

--- a/openfisca_aotearoa/variables/acts/kiwisaver/contributions.py
+++ b/openfisca_aotearoa/variables/acts/kiwisaver/contributions.py
@@ -1,0 +1,62 @@
+"""KiwiSaver contribution rate parameters — basic minimum employee/employer amounts.
+
+This is a thin surface for comparative validation. It applies the published
+minimum/default rates to a gross earnings input. Eligibility, contribution
+holidays, ESCT, Crown contributions, and opted-up employee rates are out of
+scope.
+"""
+
+from openfisca_core.periods import YEAR
+from openfisca_core.variables import Variable
+
+from openfisca_aotearoa.entities import Person
+from openfisca_aotearoa.variables.acts.income_tax.individual import (
+    _nz_tax_year_april_instant,
+    )
+
+
+class kiwisaver__gross_salary_or_wages(Variable):
+    value_type = float
+    entity = Person
+    definition_period = YEAR
+    unit = "NZD"
+    label = "Gross salary or wages used as the KiwiSaver contribution base (input)"
+    reference = "https://www.ird.govt.nz/kiwisaver/kiwisaver-individuals/making-contributions/how-much-you-need-to-contribute"
+
+
+class kiwisaver__employee_minimum_contribution(Variable):
+    value_type = float
+    entity = Person
+    definition_period = YEAR
+    unit = "NZD"
+    label = "Employee KiwiSaver contribution at the minimum/default rate"
+    reference = [
+        "https://www.ird.govt.nz/kiwisaver-changes",
+        "https://www.ird.govt.nz/kiwisaver/kiwisaver-individuals/kiwisaver-benefits",
+        ]
+
+    def formula(persons, period, parameters):
+        earnings = persons("kiwisaver__gross_salary_or_wages", period)
+        rate = parameters(
+            _nz_tax_year_april_instant(period)
+            ).kiwisaver.employee_minimum_contribution_rate
+        return earnings * rate
+
+
+class kiwisaver__employer_minimum_contribution(Variable):
+    value_type = float
+    entity = Person
+    definition_period = YEAR
+    unit = "NZD"
+    label = "Compulsory employer KiwiSaver contribution at the minimum rate"
+    reference = [
+        "https://www.ird.govt.nz/kiwisaver-changes",
+        "https://www.ird.govt.nz/kiwisaver/kiwisaver-employers/contributions-and-deductions/employer-contributions-to-kiwisaver-and-complying-funds",
+        ]
+
+    def formula(persons, period, parameters):
+        earnings = persons("kiwisaver__gross_salary_or_wages", period)
+        rate = parameters(
+            _nz_tax_year_april_instant(period)
+            ).kiwisaver.employer_minimum_contribution_rate
+        return earnings * rate


### PR DESCRIPTION
## Summary

Closes #199.

Adds current executable surfaces for selected NZ cross-engine reconciliation cases:

- individual schedule income tax before credits through the 2025+ IRD scale;
- ACC earners' levy rates, maximum earnings, and capped employee levy;
- minimum KiwiSaver employee and employer contribution rates and basic contribution formulas.

## Impacted periods and areas

- Income tax: 2021-04-01, 2024-04-01 transitional scale, and 2025-04-01 onward.
- ACC: parameter years 2023 through 2027.
- KiwiSaver: 3%, 3.5% from 2026-04-01, and 4% from 2028-04-01.
- Public API: adds variables and parameters; does not rename or remove existing surfaces.

## Sources

- IRD individual tax rates: https://www.ird.govt.nz/income-tax/income-tax-for-individuals/tax-codes-and-tax-rates-for-individuals/tax-rates-for-individuals
- Income Tax Act 2007, Schedule 1: https://www.legislation.govt.nz/act/public/2007/0097/latest/DLM1523138.html
- IRD ACC levy rates: https://www.ird.govt.nz/income-tax/income-tax-for-individuals/acc-clients-and-carers/acc-earners-levy-rates
- IRD KiwiSaver changes: https://www.ird.govt.nz/kiwisaver-changes

## Verification

- 14 targeted YAML cases pass on Python 3.11 with `openfisca-core==41.5.7`.
- Full local suite: 326 passing; the existing `test_api.py` environment failure for the `openfisca serve` path is unrelated.
- Negative gross earnings are clamped to zero and covered by regression tests.
- Added to the Rules and Processes Integration Dashboard project.

## Period convention

Year formulas resolve parameters at 1 April of the calendar year represented by `period.start`. For example, period `2026` uses the 2026-04-01 rates.

## Risks and non-goals

The package remains pinned to openfisca-core 41.x. This PR does not model full PAYE tables, secondary tax codes, self-employed ACC levies, KiwiSaver eligibility/holidays/ESCT/Crown contributions, or mid-year prorating. GitHub Actions have not started for this fork PR and require maintainer confirmation or approval.